### PR TITLE
feat(cnpg-cluster): migrate to new plugin system

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 1.2.2
+version: 1.3.0
 appVersion: "1.27.1"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.1](https://img.shields.io/badge/AppVersion-1.27.1-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.1](https://img.shields.io/badge/AppVersion-1.27.1-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 
@@ -28,7 +28,7 @@ helm install <release_name> tobi/cnpg-cluster
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.2.2
+  targetRevision: 1.3.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -43,7 +43,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.2.2
+  version: 1.3.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -72,12 +72,13 @@ cnpg-cluster:
 | backup.compression | string | `""` | Which compression algorithm should be used for cnpg backups (should be one of "gzip", "bzip2" or "snappy"), leave blank to disable compression. |
 | backup.cron | string | `"0 0 */6 * * *"` | The cron rule used for cnpg backups. By default it runs every 6 hours. |
 | backup.destinationPath | string | `""` | S3 destination path for cnpg backups (it should be set like `s3://<bucket_name>/<path>`). |
-| backup.enabled | bool | `false` | Whether or not cnpg cluster deployment should be enabled. |
+| backup.enabled | bool | `false` | Whether or not cnpg cluster backup should be enabled. |
 | backup.endpointCA.create | bool | `false` | Whether or not to create S3 CA kubernetes secret used for cnpg backups. It will use `secretName`, `endpointCA.key` and `endpointCA.value` to create the secret. |
 | backup.endpointCA.key | string | `"ca.crt"` | The secret key containing S3 CA for cnpg backups. |
 | backup.endpointCA.secretName | string | `""` | The secret name containing S3 CA for cnpg backups, leave it empty to auto-generate the secret name. |
 | backup.endpointCA.value | string | `""` | The S3 certificate used for cnpg backups. Only needed if `backup.endpointCA.create` is set to `true`. |
 | backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
+| backup.legacyMode | bool | `true` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
 | backup.retentionPolicy | string | `"14d"` | Retention policy for cnpg backups recurrences. |
 | backup.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for cnpg backups. |
 | backup.s3Credentials.accessKeyId.value | string | `""` | S3 accessKeyId value used for cnpg backups. Only needed if `backup.s3Credentials.create` is set to `true`. |

--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -109,3 +109,39 @@ Labels
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+DEPRECATED: Legacy backup configuration using in-tree barmanObjectStore.
+This template will be removed in a future version when CloudNativePG drops support for the in-tree method.
+Only use this when backup.legacyMode is explicitly set to true.
+*/}}
+{{- define "template.legacy.backup" -}}
+{{- if and .Values.backup.enabled .Values.backup.legacyMode }}
+backup:
+  barmanObjectStore:
+    destinationPath: {{ .Values.backup.destinationPath }}
+    endpointURL: {{ .Values.backup.endpointURL }}
+    {{- if or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+    endpointCA:
+      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+      key: {{ .Values.backup.endpointCA.key }}
+    {{- end }}
+    s3Credentials:
+      accessKeyId:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+      secretAccessKey:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+      region:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.region.key }}
+    {{- if .Values.backup.compression }}
+    data:
+      compression: {{ .Values.backup.compression }}
+    wal:
+      compression: {{ .Values.backup.compression }}
+    {{- end }}
+  retentionPolicy: {{ .Values.backup.retentionPolicy }}
+{{- end }}
+{{- end }}

--- a/charts/cnpg-cluster/templates/backup-object-store.yaml
+++ b/charts/cnpg-cluster/templates/backup-object-store.yaml
@@ -1,0 +1,41 @@
+{{/*
+Plugin-based backup ObjectStore resource.
+Only created when backup is enabled and NOT in legacy mode.
+This uses the official barman-cloud plugin architecture.
+*/}}
+{{- if and .Values.backup.enabled (not .Values.backup.legacyMode) }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ printf "%s-%s" (include "template.fullname" .) "backup-store" }}
+  labels: {{- include "template.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations: {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  configuration:
+    destinationPath: {{ .Values.backup.destinationPath }}
+    endpointURL: {{ .Values.backup.endpointURL }}
+    {{- if or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+    endpointCA:
+      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+      key: {{ .Values.backup.endpointCA.key }}
+    {{- end }}
+    s3Credentials:
+      accessKeyId:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+      secretAccessKey:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+      region:
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.region.key }}
+    {{- if .Values.backup.compression }}
+    data:
+      compression: {{ .Values.backup.compression }}
+    wal:
+      compression: {{ .Values.backup.compression }}
+    {{- end }}
+  retentionPolicy: {{ .Values.backup.retentionPolicy }}
+{{- end }}

--- a/charts/cnpg-cluster/templates/backup-secrets.yaml
+++ b/charts/cnpg-cluster/templates/backup-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backup.enabled .Values.backup.s3Credentials.create }}
+{{- if and (eq .Values.mode "primary") .Values.backup.enabled .Values.backup.s3Credentials.create }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -13,7 +13,7 @@ data:
   {{ .Values.backup.s3Credentials.region.key | indent 2 -}}: {{ .Values.backup.s3Credentials.region.value | b64enc }}
 {{- end -}}
 
-{{- if and .Values.backup.enabled .Values.backup.endpointCA.create }}
+{{- if and (eq .Values.mode "primary") .Values.backup.enabled .Values.backup.endpointCA.create }}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/cnpg-cluster/templates/pg-cluster.yaml
+++ b/charts/cnpg-cluster/templates/pg-cluster.yaml
@@ -44,6 +44,8 @@ spec:
     {{- end }}
   {{- end }}
   resources: {{- toYaml .Values.resources | nindent 4 }}
+  {{/* DEPRECATED: Legacy in-tree backup (defined in _helpers.tpl). Remove when CNPG drops support. */}}
+  {{- include "template.legacy.backup" . | nindent 2 }}
   {{- if eq .Values.mode "primary" }}
   bootstrap:
     initdb:
@@ -75,102 +77,50 @@ spec:
       {{- end }}
   externalClusters:
   - name: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
-    barmanObjectStore:
-      wal:
-        maxParallel: {{ .Values.recovery.maxParallelWal }}
-      destinationPath: {{ .Values.recovery.destinationPath }}
-      endpointURL: {{ .Values.recovery.endpointURL }}
-      {{- if .Values.recovery.endpointCA.secretName }}
-      endpointCA:
-        name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
-        key: {{ .Values.recovery.endpointCA.key }}
-      {{- end }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
-        secretAccessKey:
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
-        region:
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.region.key }}
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "backup-store" }}
+        serverName: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
   {{- else if eq .Values.mode "replica" }}
   bootstrap:
     recovery:
       source: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
-      database: {{ .Values.dbName | default (include "template.fullname" .) }}
-      owner: {{ .Values.credentials.username | default (include "template.fullname" .) }}
       {{- if .Values.replica.extraArgs }}
       {{- toYaml .Values.replica.extraArgs | nindent 6 }}
       {{- end }}
-  externalClusters:
-  - name: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
-    barmanObjectStore:
-      wal:
-        maxParallel: {{ .Values.replica.maxParallelWal }}
-      destinationPath: {{ .Values.replica.destinationPath }}
-      endpointURL: {{ .Values.replica.endpointURL }}
-      {{- if .Values.replica.endpointCA.secretName }}
-      endpointCA:
-        name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
-        key: {{ .Values.replica.endpointCA.key }}
-      {{- end }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
-        secretAccessKey:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
-        region:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.region.key }}
-    connectionParameters:
-      host: {{ .Values.replica.host }}
-      port: {{ .Values.replica.port }}
-      dbname: {{ .Values.replica.dbName }}
-      sslmode: {{ .Values.replica.sslMode }}
-    sslKey:
-      name: {{ printf "%s-%s" (include "template.fullname" .) "replica" }}
-      key: tls.key
-    sslCert:
-      name: {{ printf "%s-%s" (include "template.fullname" .) "replica" }}
-      key: tls.crt
-    sslRootCert:
-      name: {{ printf "%s-%s" (include "template.fullname" .) "ca" }}
-      key: ca.crt
   replica:
     enabled: true
     source: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+  externalClusters:
+  - name: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    plugin:
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "replica-store" }}
+        serverName: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    {{- if .Values.replica.host }}
+    connectionParameters:
+      host: {{ .Values.replica.host }}
+      port: {{ .Values.replica.port | default 5432 | quote }}
+      dbname: {{ .Values.replica.dbName }}
+      sslmode: {{ .Values.replica.sslMode }}
+    {{- end }}
   {{- end }}
-  {{- if and .Values.backup.enabled (eq .Values.mode "primary") }}
-  backup:
-    barmanObjectStore:
-      destinationPath: {{ .Values.backup.destinationPath }}
-      endpointURL: {{ .Values.backup.endpointURL }}
-      {{- if .Values.backup.endpointCA.secretName }}
-      endpointCA:
-        name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
-        key: {{ .Values.backup.endpointCA.key }}
-      {{- end }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
-        secretAccessKey:
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
-        region:
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.region.key }}
-      {{- if .Values.backup.compression }}
-      data:
-        compression: {{ .Values.backup.compression }}
-      wal:
-        compression: {{ .Values.backup.compression }}
-      {{- end }}
-    retentionPolicy: {{ .Values.backup.retentionPolicy }}
+  {{/* Plugin-based backup and replica configuration (official barman-cloud plugin method) */}}
+  {{- if or (and .Values.backup.enabled (not .Values.backup.legacyMode)) (eq .Values.mode "replica") }}
+  plugins:
+  {{- if and .Values.backup.enabled (not .Values.backup.legacyMode) }}
+  - name: barman-cloud.cloudnative-pg.io
+    isWALArchiver: true
+    parameters:
+      barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "backup-store" }}
+  {{- end }}
+  {{- if eq .Values.mode "replica" }}
+  - name: barman-cloud.cloudnative-pg.io
+    parameters:
+      barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "replica-store" }}
+  {{- end }}
   {{- end }}
   monitoring:
     enablePodMonitor: {{ .Values.monitoring.enabled }} 

--- a/charts/cnpg-cluster/templates/replica-object-store.yaml
+++ b/charts/cnpg-cluster/templates/replica-object-store.yaml
@@ -1,0 +1,33 @@
+{{/*
+Plugin-based replica ObjectStore resource.
+Only created in replica mode using the official barman-cloud plugin architecture.
+*/}}
+{{- if eq .Values.mode "replica" }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ printf "%s-%s" (include "template.fullname" .) "replica-store" }}
+  labels: {{- include "template.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations: {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  configuration:
+    destinationPath: {{ .Values.replica.destinationPath }}
+    endpointURL: {{ .Values.replica.endpointURL }}
+    {{- if or .Values.replica.endpointCA.create .Values.replica.endpointCA.secretName }}
+    endpointCA:
+      name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
+      key: {{ .Values.replica.endpointCA.key }}
+    {{- end }}
+    s3Credentials:
+      accessKeyId:
+        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+        key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
+      secretAccessKey:
+        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+        key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
+      region:
+        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+        key: {{ .Values.replica.s3Credentials.region.key }}
+{{- end }}

--- a/charts/cnpg-cluster/templates/scheduled-backup.yaml
+++ b/charts/cnpg-cluster/templates/scheduled-backup.yaml
@@ -1,3 +1,8 @@
+{{/*
+ScheduledBackup resource.
+Uses plugin method when legacyMode is false (default).
+Uses traditional method when legacyMode is true.
+*/}}
 {{- if .Values.backup.enabled }}
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -12,4 +17,9 @@ spec:
   backupOwnerReference: self
   cluster:
     name: {{ include "template.fullname" . }}
+  {{- if not .Values.backup.legacyMode }}
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  {{- end }}
 {{- end }}

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -258,9 +258,12 @@ replica:
   # @section -- Replica mode
   extraArgs: {}
 backup:
-  # -- Whether or not cnpg cluster deployment should be enabled.
+  # -- Whether or not cnpg cluster backup should be enabled.
   # @section -- Backup
   enabled: false
+  # -- Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration.
+  # @section -- Backup
+  legacyMode: true
   # -- S3 destination path for cnpg backups (it should be set like `s3://<bucket_name>/<path>`).
   # @section -- Backup
   destinationPath: ""


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add compatibility for CNPG Bareman plugin system (https://cloudnative-pg.io/plugin-barman-cloud/docs/migration)

<!-- If needed link the issue fixed by this PR -->
<!-- Fixes # -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (typos, code examples or any documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B -->

- [x] Legacy mode

```yaml
# Test values for legacy mode (backward compatibility)
# This uses the old in-tree backup method

imageName: "ghcr.io/cloudnative-pg/postgresql:16.2"
instances: 3

backup:
  enabled: true
  legacyMode: true  # Use old in-tree method
  destinationPath: "s3://my-bucket/backups"
  endpointURL: "https://s3.amazonaws.com"
  s3Credentials:
    create: true
    accessKeyId:
      value: "test-key"
    secretAccessKey:
      value: "test-secret"
  compression: "gzip"
  cron: "0 0 */6 * * *"
  retentionPolicy: "14d"
```

- [x] Plugin mode

```yaml
# Example values.yaml for testing the barman-cloud plugin method
# This demonstrates a complete setup with backup, monitoring, and proper plugin configuration

# Basic cluster configuration
nameOverride: ""
fullnameOverride: ""

# PostgreSQL image and credentials
imageName: "ghcr.io/cloudnative-pg/postgresql:16.2"
imagePullPolicy: IfNotPresent
imageCredentials:
  username: ""
  password: ""

# Database configuration
instances: 3
dbName: "app"
enableSuperuserAccess: true
primaryUpdateStrategy: unsupervised

# Application credentials
credentials:
  username: "app"
  # Password will be auto-generated if not specified
  password: ""
  existingSecrets:
    enabled: false
    postgres:
      secretName: ""
      usernameKey: "username"
      passwordKey: "password"
    app:
      secretName: ""
      usernameKey: "username"
      passwordKey: "password"

# Storage configuration
storageClass: "standard"
pvcSize:
  data: "10Gi"
  wal: "5Gi"

# PostgreSQL parameters
parameters:
  shared_buffers: "256MB"
  max_connections: "100"
  work_mem: "4MB"
  maintenance_work_mem: "64MB"

# Backup configuration using barman-cloud plugin (default)
backup:
  enabled: true
  # legacyMode: false is the default - uses ObjectStore CRD and plugin method
  legacyMode: false
  
  # S3 configuration
  destinationPath: "s3://my-postgres-backups/cluster-prod"
  endpointURL: "https://s3.us-east-1.amazonaws.com"
  
  # S3 credentials - creates a Kubernetes secret
  s3Credentials:
    create: true
    secretName: ""  # Auto-generated if empty
    accessKeyId:
      key: "accessKeyId"
      value: "AKIAIOSFODNN7EXAMPLE"
    secretAccessKey:
      key: "secretAccessKey"
      value: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
    region:
      key: "region"
      value: "us-east-1"
  
  # Optional: S3 endpoint CA certificate
  endpointCA:
    create: false
    secretName: ""
    key: "ca.crt"
    value: ""
  
  # Backup settings
  compression: "gzip"
  cron: "0 0 */6 * * *"  # Every 6 hours
  retentionPolicy: "14d"  # 14 days retention

# Recovery mode configuration (commented - for reference)
# mode: "recovery"
# recovery:
#   destinationPath: "s3://my-postgres-backups/cluster-prod"
#   endpointURL: "https://s3.us-east-1.amazonaws.com"
#   endpointCA:
#     create: false
#     secretName: ""
#     key: "ca.crt"
#     value: ""
#   s3Credentials:
#     create: false
#     secretName: "backup-creds"  # Reference existing backup credentials
#   clusterName: "original-cluster"
#   maxParallelWal: 8
#   extraArgs:
#     recoveryTarget:
#       targetTime: "2024-01-15 10:00:00"

# Replica mode configuration (commented - for reference)
# mode: "replica"
# replica:
#   destinationPath: "s3://primary-postgres-backups/cluster-prod"
#   endpointURL: "https://s3.us-west-2.amazonaws.com"
#   endpointCA:
#     create: false
#   s3Credentials:
#     create: true
#     accessKeyId:
#       value: "PRIMARY_ACCESS_KEY"
#     secretAccessKey:
#       value: "PRIMARY_SECRET_KEY"
#     region:
#       value: "us-west-2"
#   clusterName: "cluster-primary"
#   host: "cluster-primary-rw.production.svc.cluster.local"
#   port: 5432
#   dbName: "app"
#   sslMode: "require"
#   maxParallelWal: 8

# Resources
resources:
  requests:
    memory: "1Gi"
    cpu: "500m"
  limits:
    memory: "2Gi"
    cpu: "1000m"

# Affinity
affinity:
  topologyKey: topology.kubernetes.io/zone

# Monitoring with Prometheus
monitoring:
  enabled: true
  podMonitor:
    metricRelabelings: []
    relabelings: []
    additionalLabels:
      prometheus: kube-prometheus
    extraMatchLabels: {}

# PgBouncer connection pooler
pooler:
  enabled: true
  instances: 3
  type: "rw"  # or "ro" for read-only
  pgbouncer:
    pool_mode: transaction
    max_client_conn: 1000
    default_pool_size: 25

# NodePort exposure (for development)
exposed: false
nodePort: 30000

# Logging
logLevel: "info"

# CloudNativePG operator (usually deployed separately)
cnpg-operator:
  enabled: false
```

- [x] Replica mode

```yaml
# Test values for replica cluster with plugin method

imageName: "ghcr.io/cloudnative-pg/postgresql:16.2"
instances: 3

# Replica mode configuration
mode: replica

replica:
  # Primary cluster configuration
  clusterName: "cluster-primary"
  host: "cluster-primary-rw.production.svc.cluster.local"
  port: 5432
  dbName: "app"
  sslMode: "require"
  
  # S3 configuration for primary cluster's backups
  destinationPath: "s3://primary-backups/cluster-primary"
  endpointURL: "https://s3.us-west-2.amazonaws.com"
  
  s3Credentials:
    create: true
    accessKeyId:
      value: "PRIMARY_ACCESS_KEY"
    secretAccessKey:
      value: "PRIMARY_SECRET_KEY"
    region:
      value: "us-west-2"
  
  maxParallelWal: 8

# Optional: Enable backup on replica cluster too (for DR)
backup:
  enabled: true
  legacyMode: false
  destinationPath: "s3://replica-backups/cluster-replica"
  endpointURL: "https://s3.us-east-1.amazonaws.com"
  s3Credentials:
    create: true
    accessKeyId:
      value: "REPLICA_ACCESS_KEY"
    secretAccessKey:
      value: "REPLICA_SECRET_KEY"
    region:
      value: "us-east-1"
  compression: "gzip"
  cron: "0 0 */6 * * *"
  retentionPolicy: "14d"

resources:
  requests:
    memory: "1Gi"
    cpu: "500m"
  limits:
    memory: "2Gi"
    cpu: "1000m"

monitoring:
  enabled: true
```

**Test Configuration**:
- Firmware version: Darwin 24.0.0 arm64
- Hardware: Apple M3 Max
- Toolchain:
  - Helm

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
