### PR TITLE
feat: improve chart robustness and fix edge cases

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.2.1
+version: 2.2.2
 appVersion: "1.0.0"
 description: Production-ready Helm chart for automated backups of PostgreSQL, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
@@ -10,13 +10,15 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: added
-      description: JSON Schema validation (values.schema.json) for configuration validation and IDE auto-completion
+      description: Default image repository (ghcr.io/this-is-tobi/tools/backup) and tag (appVersion)
     - kind: added
-      description: extraObjects support for deploying additional Kubernetes resources dynamically
+      description: Default values for all job parameters (successfulJobsHistoryLimit, failedJobsHistoryLimit, concurrencyPolicy, timeZone, backoffLimit)
     - kind: added
-      description: OCI registry distribution via ghcr.io/this-is-tobi/helm-charts
+      description: Default pod restartPolicy (Never) and resource requests/limits
     - kind: changed
-      description: Updated chart metadata and documentation
+      description: Schema now accepts both string and number types for secrets (e.g., DB_PORT)
+    - kind: fixed
+      description: Added toString conversion before b64enc in secret helper to handle numeric values correctly
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.2.2](https://img.shields.io/badge/Version-2.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -49,7 +49,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.2.1
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.2.2
 ```
 
 ### ArgoCD
@@ -65,7 +65,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.2.1
+    targetRevision: 2.2.2
     helm:
       releaseName: <release_name>
       values: |
@@ -94,7 +94,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.2.1
+    targetRevision: 2.2.2
     helm:
       releaseName: <release_name>
       values: |
@@ -119,7 +119,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.2.1
+  version: 2.2.2
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -129,7 +129,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.2.1
+  version: 2.2.2
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```

--- a/charts/backup-utils/templates/_helpers.tpl
+++ b/charts/backup-utils/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Create container environment variables from secret
 */}}
 {{- define "backup-utils.secret" -}}
 {{- range $key, $val := .secrets }}
-{{ $key }}: {{ $val | b64enc | quote }}
+{{ $key }}: {{ $val | toString | b64enc | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/backup-utils/templates/cronjob.yaml
+++ b/charts/backup-utils/templates/cronjob.yaml
@@ -9,9 +9,9 @@ metadata:
     {{- include "backup-utils.labels" (list $ $backupName) | nindent 4 }}
 spec:
   schedule: {{ $backup.job.schedule }}
-  successfulJobsHistoryLimit: {{ $backup.job.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ $backup.job.failedJobsHistoryLimit }}
-  concurrencyPolicy: {{ $backup.job.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ $backup.job.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ $backup.job.failedJobsHistoryLimit | default 3 }}
+  concurrencyPolicy: {{ $backup.job.concurrencyPolicy | default "Forbid" }}
   timeZone: {{ $backup.job.timeZone | default "UTC" }}
   jobTemplate:
     metadata:
@@ -27,7 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      backoffLimit: {{ $backup.job.backoffLimit }}
+      backoffLimit: {{ $backup.job.backoffLimit | default 3 }}
       template:
         metadata:
           {{- if $backup.podAnnotations }}
@@ -46,7 +46,7 @@ spec:
           imagePullSecrets:
           - name: {{ include "backup-utils.name" $ }}-pullsecret
           {{- end }}
-          restartPolicy: {{ $backup.restartPolicy }}
+          restartPolicy: {{ $backup.restartPolicy | default "Never" }}
           {{- if $backup.podSecurityContext }}
           securityContext:
             {{- toYaml $backup.podSecurityContext | nindent 12 }}
@@ -57,8 +57,20 @@ spec:
             securityContext:
               {{- toYaml $backup.container.securityContext | nindent 14 }}
             {{- end }}
-            image: {{ printf "%s:%s" $backup.image.repository ($backup.image.tag | default "latest") }}
-            imagePullPolicy: {{ $backup.image.pullPolicy }}
+            {{- $imageRepo := "ghcr.io/this-is-tobi/tools/backup" }}
+            {{- if and $backup.image (hasKey $backup.image "repository") }}
+            {{- $imageRepo = $backup.image.repository }}
+            {{- end }}
+            {{- $imageTag := $.Chart.AppVersion }}
+            {{- if and $backup.image (hasKey $backup.image "tag") }}
+            {{- $imageTag = $backup.image.tag }}
+            {{- end }}
+            image: {{ printf "%s:%s" $imageRepo $imageTag }}
+            {{- $pullPolicy := "IfNotPresent" }}
+            {{- if and $backup.image (hasKey $backup.image "pullPolicy") }}
+            {{- $pullPolicy = $backup.image.pullPolicy }}
+            {{- end }}
+            imagePullPolicy: {{ $pullPolicy }}
             {{- if and $backup.container (hasKey $backup.container "command") }}
             command:
             {{- range $backup.container.command }}
@@ -90,7 +102,17 @@ spec:
             {{- if $backup.envFrom }}
               {{- toYaml $backup.envFrom | nindent 12 }}
             {{- end }}
+            {{- if $backup.resources }}
             resources:
               {{- toYaml $backup.resources | nindent 14 }}
+            {{- else }}
+            resources:
+              requests:
+                memory: "128Mi"
+                cpu: "100m"
+              limits:
+                memory: "512Mi"
+                cpu: "250m"
+            {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/backup-utils/values.schema.json
+++ b/charts/backup-utils/values.schema.json
@@ -199,7 +199,7 @@
           "secrets": {
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": ["string", "number"]
             }
           },
           "resources": {

--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "1.27.1"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io
@@ -11,11 +11,9 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: added
-      description: JSON Schema validation (values.schema.json) for improved configuration validation and IDE support
-    - kind: added
-      description: extraObjects support for deploying additional Kubernetes resources dynamically
-    - kind: added
-      description: OCI registry distribution via ghcr.io/this-is-tobi/helm-charts
+      description: Default value for pooler.instances in template and schema (default 3)
+    - kind: fixed
+      description: Prevent nil pointer error when pooler is enabled without specifying instances
 keywords:
 - postgresql
 - postgres

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.1](https://img.shields.io/badge/AppVersion-1.27.1-informational?style=flat-square)
+![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.27.1](https://img.shields.io/badge/AppVersion-1.27.1-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 
@@ -23,7 +23,7 @@ helm install <release_name> tobi/cnpg-cluster
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 1.5.0
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 1.5.1
 ```
 
 ### ArgoCD
@@ -34,7 +34,7 @@ helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster 
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.5.0
+  targetRevision: 1.5.1
   helm:
     releaseName: <release_name>
     parameters: []
@@ -47,7 +47,7 @@ sources:
 sources:
 - repoURL: ghcr.io/this-is-tobi/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.5.0
+  targetRevision: 1.5.1
   helm:
     releaseName: <release_name>
     parameters: []
@@ -62,7 +62,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.5.0
+  version: 1.5.1
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -73,7 +73,7 @@ dependencies:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.5.0
+  version: 1.5.1
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -140,7 +140,7 @@ infosSecret:
     name: "POSTGRES_DB"               # Instead of DB_NAME
     user: "POSTGRES_USER"             # Instead of DB_USER
     password: "POSTGRES_PASSWORD"     # Instead of DB_PASS
-    connectionString: "DATABASE_URL"  # Instead of DB_URL
+    url: "DATABASE_URL"               # Instead of DB_URL
 ```
 
 **Usage example with backup-utils:**

--- a/charts/cnpg-cluster/README.md.gotmpl
+++ b/charts/cnpg-cluster/README.md.gotmpl
@@ -138,7 +138,7 @@ infosSecret:
     name: "POSTGRES_DB"               # Instead of DB_NAME
     user: "POSTGRES_USER"             # Instead of DB_USER
     password: "POSTGRES_PASSWORD"     # Instead of DB_PASS
-    connectionString: "DATABASE_URL"  # Instead of DB_URL
+    url: "DATABASE_URL"               # Instead of DB_URL
 ```
 
 **Usage example with backup-utils:**

--- a/charts/cnpg-cluster/templates/pg-pooler.yaml
+++ b/charts/cnpg-cluster/templates/pg-pooler.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  instances: {{ .Values.pooler.instances }}
+  instances: {{ .Values.pooler.instances | default 3 }}
   cluster:
     name: {{ include "template.fullname" . }}
   type: {{ .Values.pooler.type }}

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -292,7 +292,8 @@
         },
         "instances": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "default": 3
         },
         "type": {
           "type": "string",

--- a/charts/vso-utils/Chart.yaml
+++ b/charts/vso-utils/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vso-utils
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.10.0"
 description: Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 deprecated: false
@@ -9,12 +9,8 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: added
-      description: JSON Schema validation (values.schema.json) for VSO resource configuration
-    - kind: added
-      description: extraObjects support for deploying additional Kubernetes resources dynamically
-    - kind: added
-      description: OCI registry distribution via ghcr.io/this-is-tobi/helm-charts
+    - kind: fixed
+      description: Added toString conversion before b64enc in vso-utils.secret helper for type safety (preventive fix)
 keywords:
 - vault
 - secrets

--- a/charts/vso-utils/README.md
+++ b/charts/vso-utils/README.md
@@ -1,6 +1,6 @@
 # vso-utils
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/vso-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 1.1.0
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 1.1.1
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.0
+    targetRevision: 1.1.1
     helm:
       releaseName: <release_name>
       values: |
@@ -93,7 +93,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.0
+    targetRevision: 1.1.1
     helm:
       releaseName: <release_name>
       values: |
@@ -116,7 +116,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.0
+  version: 1.1.1
   repository: https://this-is-tobi.github.io/helm-charts
   condition: vso-utils.enabled
 ```
@@ -126,7 +126,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.0
+  version: 1.1.1
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: vso-utils.enabled
 ```

--- a/charts/vso-utils/templates/_helpers.tpl
+++ b/charts/vso-utils/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Create container environment variables from secret
 */}}
 {{- define "vso-utils.secret" -}}
 {{ range $key, $val := .secrets }}
-{{ $key }}: {{ $val | b64enc | quote }}
+{{ $key }}: {{ $val | toString | b64enc | quote }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Description

This PR improves the robustness of three Helm charts by adding sensible defaults, fixing type conversion issues, and preventing potential runtime errors.

### Changes Summary

**backup-utils v2.2.2:**
- Added default image repository (`ghcr.io/this-is-tobi/tools/backup`) and tag (uses `appVersion`)
- Added defaults for all job parameters (successfulJobsHistoryLimit, failedJobsHistoryLimit, concurrencyPolicy, timeZone, backoffLimit)
- Added default pod restartPolicy (Never) and resource requests/limits
- Schema now accepts both string and number types for secrets (e.g., `DB_PORT: 5432` without `--set-string`)
- Fixed toString conversion before b64enc in secret helper to handle numeric values correctly

**cnpg-cluster v1.5.1:**
- Added default value for `pooler.instances` in template and schema (default: 3)
- Fixed potential nil pointer error when pooler is enabled without specifying instances
- Fixed documentation typo (`connectionString` → `url`)

**vso-utils v1.1.1:**
- Added preventive toString conversion before b64enc in unused secret helper for type safety

**Workflow:**
- Added Docker login for Cosign authentication (Cosign uses Docker credential store, not Helm's registry login)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (typos, code examples or any documentation update)
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Helm lint on all three charts (backup-utils, cnpg-cluster, vso-utils) - all passed
- [x] Helm dry-run installation of backup-utils with PostgreSQL configuration
- [x] Schema validation with numeric values for secrets (DB_PORT without --set-string)
- [x] Template rendering verification for all default values
- [x] No compilation or validation errors detected

**Test Configuration**:
- Helm version: 3.x
- Kubernetes: Tested with dry-run validation
- Charts: backup-utils 2.2.2, cnpg-cluster 1.5.1, vso-utils 1.1.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (helm lint, dry-run validation)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Impact

These changes improve user experience by:
1. **Reducing configuration burden**: Users can now use charts with minimal values
2. **Preventing errors**: Defaults prevent nil pointer errors and type mismatches
3. **Maintaining flexibility**: Schema still allows overrides for all default values
4. **Better DX**: Numeric ports work without --set-string flags