### PR TITLE
fix(vso-utils): use method-specific configuration blocks for VaultAuth

### DIFF
--- a/charts/vso-utils/Chart.yaml
+++ b/charts/vso-utils/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vso-utils
 type: application
-version: 1.1.3
+version: 1.1.4
 appVersion: "0.10.0"
 description: Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 deprecated: false
@@ -10,11 +10,15 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fixed VaultAuth params rendering to properly handle audiences field (supports both string and array formats, converts arrays to comma-separated strings)
-    - kind: fixed
-      description: Fixed VaultAuth params to properly quote string values in output YAML
-    - kind: added
-      description: Added comprehensive JSON schema validation for all VSO resource types (vaultStaticSecrets, vaultDynamicSecrets, vaultPKISecrets, vaultAuth, vaultConnection)
+      description: |
+        Fixed VaultAuth template to use method-specific configuration blocks (kubernetes, jwt, appRole, aws, gcp) 
+        instead of generic params field, matching VSO API specification. This is a BREAKING CHANGE - update your 
+        values to use typed auth configs, e.g., `kubernetes: { role, serviceAccount, audiences }` instead of 
+        `params: { role, serviceAccount, audiences }`.
+    - kind: changed
+      description: Updated JSON schema to reflect proper VaultAuth structure with typed auth method configurations
+    - kind: changed
+      description: Updated test-values.yaml to demonstrate correct VaultAuth configuration structure
 keywords:
 - vault
 - secrets

--- a/charts/vso-utils/README.md
+++ b/charts/vso-utils/README.md
@@ -1,6 +1,6 @@
 # vso-utils
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/vso-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 1.1.3
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 1.1.4
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.3
+    targetRevision: 1.1.4
     helm:
       releaseName: <release_name>
       values: |
@@ -93,7 +93,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.3
+    targetRevision: 1.1.4
     helm:
       releaseName: <release_name>
       values: |
@@ -116,7 +116,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.3
+  version: 1.1.4
   repository: https://this-is-tobi.github.io/helm-charts
   condition: vso-utils.enabled
 ```
@@ -126,7 +126,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.3
+  version: 1.1.4
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: vso-utils.enabled
 ```

--- a/charts/vso-utils/templates/vault-auth.yaml
+++ b/charts/vso-utils/templates/vault-auth.yaml
@@ -17,19 +17,29 @@ spec:
   {{- end }}
   method: {{ $auth.method | required (printf "method is required for VaultAuth %s" $authName) }}
   mount: {{ $auth.mount | required (printf "mount is required for VaultAuth %s" $authName) }}
+  {{- with $auth.kubernetes }}
+  kubernetes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $auth.jwt }}
+  jwt:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $auth.appRole }}
+  appRole:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $auth.aws }}
+  aws:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $auth.gcp }}
+  gcp:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $auth.params }}
   params:
-    {{- range $key, $value := . }}
-    {{- if eq $key "audiences" }}
-    {{- if kindIs "slice" $value }}
-    audiences: {{ join "," $value | quote }}
-    {{- else }}
-    audiences: {{ $value | quote }}
-    {{- end }}
-    {{- else }}
-    {{ $key }}: {{ $value | toYaml }}
-    {{- end }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with $auth.headers }}
   headers:

--- a/charts/vso-utils/test-values.yaml
+++ b/charts/vso-utils/test-values.yaml
@@ -16,7 +16,7 @@ vaultAuth:
     method: kubernetes
     mount: kubernetes
     vaultConnectionRef: default
-    params:
+    kubernetes:
       role: "my-app-role"
       serviceAccount: "default"
       audiences:
@@ -26,7 +26,7 @@ vaultAuth:
     method: appRole
     mount: approle
     vaultConnectionRef: default
-    params:
+    appRole:
       roleId: "my-role-id"
       secretRef: "approle-secret"
 

--- a/charts/vso-utils/values.schema.json
+++ b/charts/vso-utils/values.schema.json
@@ -169,27 +169,89 @@
           "namespace": { "type": "string" },
           "method": { 
             "type": "string",
-            "enum": ["kubernetes", "jwt", "appRole", "aws", "gcp", "ldap"]
+            "enum": ["kubernetes", "jwt", "appRole", "aws", "gcp"]
           },
           "mount": { "type": "string" },
-          "params": { 
+          "kubernetes": {
             "type": "object",
+            "description": "Kubernetes auth method configuration",
             "properties": {
               "role": { "type": "string" },
               "serviceAccount": { "type": "string" },
               "audiences": { 
-                "oneOf": [
-                  { "type": "string" },
-                  { "type": "array", "items": { "type": "string" } }
-                ]
+                "type": "array",
+                "items": { "type": "string" }
               },
+              "tokenExpirationSeconds": { 
+                "type": "integer",
+                "minimum": 600,
+                "default": 600
+              }
+            }
+          },
+          "jwt": {
+            "type": "object",
+            "description": "JWT auth method configuration",
+            "properties": {
+              "role": { "type": "string" },
+              "secretRef": { "type": "string" },
+              "serviceAccount": { "type": "string" },
+              "audiences": { 
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "tokenExpirationSeconds": { 
+                "type": "integer",
+                "minimum": 600,
+                "default": 600
+              }
+            }
+          },
+          "appRole": {
+            "type": "object",
+            "description": "AppRole auth method configuration",
+            "properties": {
               "roleId": { "type": "string" },
               "secretRef": { "type": "string" }
             }
           },
+          "aws": {
+            "type": "object",
+            "description": "AWS auth method configuration",
+            "properties": {
+              "role": { "type": "string" },
+              "region": { "type": "string" },
+              "headerValue": { "type": "string" },
+              "sessionName": { "type": "string" },
+              "stsEndpoint": { "type": "string" },
+              "iamEndpoint": { "type": "string" },
+              "secretRef": { "type": "string" },
+              "irsaServiceAccount": { "type": "string" }
+            }
+          },
+          "gcp": {
+            "type": "object",
+            "description": "GCP auth method configuration",
+            "properties": {
+              "role": { "type": "string" },
+              "workloadIdentityServiceAccount": { "type": "string" },
+              "region": { "type": "string" },
+              "clusterName": { "type": "string" },
+              "projectID": { "type": "string" }
+            }
+          },
+          "params": { 
+            "type": "object",
+            "description": "Generic params for additional auth configuration not covered by typed fields"
+          },
           "headers": { "type": "object" },
           "vaultConnectionRef": { "type": "string" },
-          "storageEncryption": { "type": "object" }
+          "storageEncryption": { "type": "object" },
+          "vaultAuthGlobalRef": { "type": "object" },
+          "allowedNamespaces": { 
+            "type": "array",
+            "items": { "type": "string" }
+          }
         }
       }
     },

--- a/charts/vso-utils/values.yaml
+++ b/charts/vso-utils/values.yaml
@@ -212,35 +212,66 @@ vaultPKISecrets: {}
 # VaultAuth resources for configuring Vault authentication.
 # See: https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauth
 vaultAuth: {}
-  # Example configuration:
+  # Example configurations:
+  # 
+  # Kubernetes auth method:
   # default:
-  #   # -- Additional annotations for the VaultAuth resource.
-  #   annotations: {}
-  #   # -- Additional labels for the VaultAuth resource.
-  #   labels: {}
-  #   # -- Namespace in Vault for authentication.
-  #   namespace: ""
-  #   # -- Vault authentication method ("kubernetes", "jwt", "appRole", "aws", "gcp", "ldap").
   #   method: "kubernetes"
-  #   # -- Mount path of the auth method in Vault (required).
   #   mount: "kubernetes"
-  #   # -- Parameters specific to the authentication method.
-  #   params: {}
-  #     # For Kubernetes auth:
-  #     # role: "my-role"
-  #     # serviceAccount: "default"
-  #     # audiences: ["vault"]
-  #     # For AppRole:
-  #     # roleId: "my-role-id"
-  #     # secretRef: "approle-secret"
-  #   # -- Headers to include in Vault requests.
-  #   headers: {}
-  #   # -- Vault connection reference (optional, defaults to "default").
   #   vaultConnectionRef: "default"
-  #   # -- StorageEncryption configuration for encrypting cached credentials.
-  #   storageEncryption: {}
-  #     # keyName: "encryption-key"
-  #     # mount: "transit"
+  #   kubernetes:
+  #     role: "my-app-role"
+  #     serviceAccount: "default"
+  #     audiences: ["vault"]
+  #     tokenExpirationSeconds: 600
+  #
+  # JWT auth method:
+  # jwtAuth:
+  #   method: "jwt"
+  #   mount: "jwt"
+  #   jwt:
+  #     role: "my-role"
+  #     secretRef: "jwt-token-secret"  # Secret containing JWT token in 'jwt' key
+  #
+  # AppRole auth method:
+  # appRoleAuth:
+  #   method: "appRole"
+  #   mount: "approle"
+  #   appRole:
+  #     roleId: "my-role-id"
+  #     secretRef: "approle-secret"  # Secret containing SecretID in 'id' key
+  #
+  # AWS auth method:
+  # awsAuth:
+  #   method: "aws"
+  #   mount: "aws"
+  #   aws:
+  #     role: "my-aws-role"
+  #     region: "us-east-1"
+  #     # Optional:
+  #     irsaServiceAccount: "my-sa"  # For EKS IRSA
+  #     secretRef: "aws-credentials"  # For static credentials
+  #
+  # GCP auth method:
+  # gcpAuth:
+  #   method: "gcp"
+  #   mount: "gcp"
+  #   gcp:
+  #     role: "my-gcp-role"
+  #     workloadIdentityServiceAccount: "my-sa@project.iam.gserviceaccount.com"
+  #     region: "us-central1"
+  #     clusterName: "my-cluster"
+  #     projectID: "my-project"
+  #
+  # Common optional fields for all auth methods:
+  #   annotations: {}
+  #   labels: {}
+  #   namespace: ""  # Vault namespace (Enterprise)
+  #   headers: {}
+  #   params: {}  # Generic params for additional configuration
+  #   storageEncryption:
+  #     keyName: "encryption-key"
+  #     mount: "transit"
 
 
 # VaultConnection resources for configuring Vault server connection details.


### PR DESCRIPTION
## Description

Fixed VaultAuth template to properly follow the Vault Secrets Operator API specification by using method-specific configuration blocks (`kubernetes`, `jwt`, `appRole`, `aws`, `gcp`) instead of the generic `params` field.

This change aligns the chart with the official VSO API structure documented at https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultauth

### Changes Made:
- Updated `vault-auth.yaml` template to support typed auth method configurations
- Modified JSON schema to reflect proper VaultAuth structure with validation for each auth method
- Updated `test-values.yaml` with correct configuration examples
- Enhanced `values.yaml` documentation with comprehensive examples for all auth methods
- Bumped chart version to 1.1.4

### Migration Guide:
**Before (❌ Incorrect):**
```yaml
vaultAuth:
  default:
    method: kubernetes
    mount: kubernetes
    params:
      role: "my-role"
      serviceAccount: "default"
      audiences: ["vault"]
```

**After (✅ Correct):**
```yaml
vaultAuth:
  default:
    method: kubernetes
    mount: kubernetes
    kubernetes:
      role: "my-role"
      serviceAccount: "default"
      audiences: ["vault"]
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (typos, code examples or any documentation update)
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Helm template rendering with test-values.yaml
- [x] Helm lint validation
- [x] Verified output matches VSO API specification
- [x] Tested both kubernetes and appRole auth methods

**Test Configuration**:
- Chart version: 1.1.4
- VSO appVersion: 0.10.0
- Helm: v3.x

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings