### PR TITLE
chore(cnpg-cluster): disabled legacy backup mode by default

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.3.3
-appVersion: "1.1.2"
+version: 2.3.4
+appVersion: "1.1.3"
 description: Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
 annotations:
@@ -10,7 +10,7 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade backup image to v1.1.2
+      description: Upgrade backup image to v1.1.3
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.3.3](https://img.shields.io/badge/Version-2.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 2.3.4](https://img.shields.io/badge/Version-2.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.3](https://img.shields.io/badge/AppVersion-1.1.3-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.3
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.4
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.3
+    targetRevision: 2.3.4
     helm:
       releaseName: <release_name>
       values: |
@@ -95,7 +95,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.3
+    targetRevision: 2.3.4
     helm:
       releaseName: <release_name>
       values: |
@@ -120,7 +120,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.3
+  version: 2.3.4
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -130,7 +130,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.3
+  version: 2.3.4
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```


### PR DESCRIPTION
## Description

This PR upgrades the backup-utils chart to version 2.3.4, updating the backup image to v1.1.3.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (typos, code examples or any documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Chart linting passes
- [x] Template rendering validation

**Test Configuration**:
- Firmware version: N/A
- Hardware: N/A
- Toolchain: Helm v3

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings