### PR TITLE
add image registry

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -22,6 +22,7 @@ A Helm chart to deploy chartname.
 | global.envCm | object | `{}` | Map of environment variables to inject into a configmap loaded by all containers (`valueFrom` not supported). |
 | global.envSecret | object | `{}` | Map of environment variables to inject into a secret loaded by all containers (`valueFrom` not supported). |
 | global.httpRoute | object | `{}` | Globally shared httproute configuration. |
+| global.imageRegistry | string | `""` | Global Docker image registry |
 | global.ingress | object | `{}` | Globally shared ingress configuration. |
 
 ### Gateway
@@ -108,7 +109,8 @@ A Helm chart to deploy chartname.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | servicename.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the app. |
-| servicename.image.repository | string | `"docker.io/debian"` | Repository to use for the app. |
+| servicename.image.registry | string | `"docker.io"` | Registry to use for the app. |
+| servicename.image.repository | string | `"debian"` | Repository to use for the app. |
 | servicename.image.tag | string | `""` | Tag to use for the app. Overrides the image tag whose default is the chart appVersion. |
 
 #### Ingress

--- a/template/templates/servicename/deployment.yaml
+++ b/template/templates/servicename/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{- if .Values.servicename.securityContext }}
         securityContext: {{- toYaml .Values.servicename.securityContext | nindent 10 }}
         {{- end }}
-        image: "{{ .Values.servicename.image.repository }}:{{ .Values.servicename.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.servicename.image.registry }}/{{ .Values.servicename.image.repository }}:{{ .Values.servicename.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.servicename.image.pullPolicy }}
         {{- if .Values.servicename.command }}
         command:

--- a/template/templates/servicename/statefulset.yaml
+++ b/template/templates/servicename/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if .Values.servicename.securityContext }}
         securityContext: {{- toYaml .Values.servicename.securityContext | nindent 10 }}
         {{- end }}
-        image: "{{ .Values.servicename.image.repository }}:{{ .Values.servicename.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.global.imageRegistry | default .Values.servicename.image.registry }}/{{ .Values.servicename.image.repository }}:{{ .Values.servicename.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.servicename.image.pullPolicy }}
         {{- if .Values.servicename.command }}
         command:

--- a/template/values.yaml
+++ b/template/values.yaml
@@ -22,7 +22,7 @@ global:
     #       name: "my-secret"
     #       key: "C"
     #
-    # - name: "A" 
+    # - name: "A"
     #   value: "A"
     # - name: "B"
     #   valueFrom:
@@ -42,6 +42,10 @@ global:
   # @section -- Global
   envSecret: {}
     # E: "E"
+
+  # -- Global Docker image registry
+  # @section -- Global
+  imageRegistry: ""
   # -- Globally shared ingress configuration.
   # @section -- Global
   ingress: {}
@@ -164,9 +168,12 @@ servicename:
   # @section -- Servicename
   replicaCount: 1
   image:
+    # -- Registry to use for the app.
+    # @section -- Servicename
+    registry: "docker.io"
     # -- Repository to use for the app.
     # @section -- Servicename
-    repository: "docker.io/debian"
+    repository: "debian"
     # -- Image pull policy for the app.
     # @section -- Servicename
     pullPolicy: "IfNotPresent"
@@ -372,7 +379,7 @@ servicename:
     #       name: "my-secret"
     #       key: "C"
     #
-    # - name: "A" 
+    # - name: "A"
     #   value: "A"
     # - name: "B"
     #   valueFrom:
@@ -558,7 +565,7 @@ servicename:
     extraPorts: []
     # - port: 9090
     #   targetPort: 9090
-    #   protocol: "TCP" 
+    #   protocol: "TCP"
     #   name: "metrics"
   resources:
     requests:


### PR DESCRIPTION
## Description

Add possibility to customize image registry and add an option for a global image registry

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Helm template without and with global.imageRegistry. The templated output is ok for deployment and sts

**Test Configuration**:
helm version.BuildInfo{Version:"v3.19.2", GitCommit:"8766e718a0119851f10ddbe4577593a45fadf544", GitTreeState:"clean", GoVersion:"go1.24.9"}


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
