### PR TITLE
ci: upgrade github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checks-out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checks-out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run helm-docs
         run: ./ci/scripts/helm-docs.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write  # Required for OIDC authentication with Sigstore/Cosign
     steps:
       - name: Checks-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install Cosign for OCI signing
         if: steps.chart-releaser.outputs.changed_charts != ''
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Publish and sign charts to OCI registry
         if: steps.chart-releaser.outputs.changed_charts != ''


### PR DESCRIPTION
## Description

Upgrade outdated GitHub Actions to their latest versions across CI workflows:

- `actions/checkout`: `v4`/`v5` → `v6` (both `ci.yaml` and `release.yaml`)
- `sigstore/cosign-installer`: `v3` → `v4` (`release.yaml`)

<!-- Fixes # -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (typos, code examples or any documentation update)
- [x] Other (please describe): GitHub Actions version bumps to keep CI dependencies up to date.

## How Has This Been Tested?

Workflows will be validated on first run after merge. No logic changes were made — only action version pins were updated.

**Test Configuration**:
- Firmware version: N/A
- Hardware: N/A
- Toolchain: GitHub Actions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings