### PR TITLE
feat(cnpg-cluster): recovery/legacy fixes, plugin extra params & declarative database management

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.28.1"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io
@@ -10,8 +10,16 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Disable backup resources (ObjectStore, ScheduledBackup, plugins) during recovery mode to prevent WAL archive collision.
+    - kind: fixed
+      description: Support legacy barmanObjectStore in recovery and replica externalClusters when `backup.legacyMode` is `true`.
     - kind: added
-      description: Added `extraSpec` field to allow additional specifications in the CNPG cluster manifest.
+      description: Added separate recovery ObjectStore for plugin mode to avoid reusing the backup destination path.
+    - kind: added
+      description: Added `backup.pluginExtraParameters` to pass extra parameters to the barman-cloud backup plugin.
+    - kind: added
+      description: Added declarative database management via the CNPG Database CRD (`databases` key in values).
 keywords:
 - postgresql
 - postgres

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 
@@ -23,7 +23,7 @@ helm install <release_name> tobi/cnpg-cluster
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 1.6.0
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 1.7.0
 ```
 
 ### ArgoCD
@@ -34,7 +34,7 @@ helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster 
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.6.0
+  targetRevision: 1.7.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -47,7 +47,7 @@ sources:
 sources:
 - repoURL: ghcr.io/this-is-tobi/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.6.0
+  targetRevision: 1.7.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -62,7 +62,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.6.0
+  version: 1.7.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -73,7 +73,7 @@ dependencies:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.6.0
+  version: 1.7.0
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -426,6 +426,7 @@ backup-utils:
 | backup.endpointCA.value | string | `""` | The S3 certificate used for cnpg backups. Only needed if `backup.endpointCA.create` is set to `true`. |
 | backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
 | backup.legacyMode | bool | `true` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
+| backup.pluginExtraParameters | object | `{}` | Extra parameters to pass to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery). Only used when `backup.legacyMode` is set to `false`. |
 | backup.retentionPolicy | string | `"14d"` | Retention policy for cnpg backups recurrences. |
 | backup.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for cnpg backups. |
 | backup.s3Credentials.accessKeyId.value | string | `""` | S3 accessKeyId value used for cnpg backups. Only needed if `backup.s3Credentials.create` is set to `true`. |
@@ -564,6 +565,7 @@ backup-utils:
 |-----|------|---------|-------------|
 | annotations | object | `{}` | Additional annotations for created resources. |
 | cnpg-operator.enabled | bool | `false` | Whether or not cnpg operator should be deployed (See. https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg?modal=values). |
+| databases | list | `[]` |  |
 | extraObjects | list | `[]` | Add extra specs dynamically to this chart. |
 | fullnameOverride | string | `""` | String to fully override the default application name. |
 | labels | object | `{}` | Additional cnpg cluster labels. |

--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -116,7 +116,7 @@ This template will be removed in a future version when CloudNativePG drops suppo
 Only use this when backup.legacyMode is explicitly set to true.
 */}}
 {{- define "template.legacy.backup" -}}
-{{- if and .Values.backup.enabled .Values.backup.legacyMode }}
+{{- if and .Values.backup.enabled .Values.backup.legacyMode (ne .Values.mode "recovery") }}
 backup:
   barmanObjectStore:
     destinationPath: {{ .Values.backup.destinationPath }}

--- a/charts/cnpg-cluster/templates/backup-object-store.yaml
+++ b/charts/cnpg-cluster/templates/backup-object-store.yaml
@@ -1,9 +1,4 @@
-{{/*
-Plugin-based backup ObjectStore resource.
-Only created when backup is enabled and NOT in legacy mode.
-This uses the official barman-cloud plugin architecture.
-*/}}
-{{- if and .Values.backup.enabled (not .Values.backup.legacyMode) }}
+{{- if and .Values.backup.enabled (not .Values.backup.legacyMode) (ne .Values.mode "recovery") }}
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/charts/cnpg-cluster/templates/databases.yaml
+++ b/charts/cnpg-cluster/templates/databases.yaml
@@ -1,0 +1,77 @@
+{{- $fullname := include "template.fullname" . }}
+{{- $labels := include "template.labels" . }}
+{{- if and .Values.databases (ne .Values.mode "replica") }}
+{{- range .Values.databases }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: {{ printf "%s-db-%s" $fullname .name }}
+  labels: {{- $labels | nindent 4 }}
+spec:
+  name: {{ .name }}
+  owner: {{ .owner }}
+  cluster:
+    name: {{ $fullname }}
+  {{- if .ensure }}
+  ensure: {{ .ensure }}
+  {{- end }}
+  {{- if .databaseReclaimPolicy }}
+  databaseReclaimPolicy: {{ .databaseReclaimPolicy }}
+  {{- end }}
+  {{- if .template }}
+  template: {{ .template }}
+  {{- end }}
+  {{- if .encoding }}
+  encoding: {{ .encoding }}
+  {{- end }}
+  {{- if .locale }}
+  locale: {{ .locale }}
+  {{- end }}
+  {{- if .localeProvider }}
+  localeProvider: {{ .localeProvider }}
+  {{- end }}
+  {{- if .localeCollate }}
+  localeCollate: {{ .localeCollate }}
+  {{- end }}
+  {{- if .localeCType }}
+  localeCType: {{ .localeCType }}
+  {{- end }}
+  {{- if .icuLocale }}
+  icuLocale: {{ .icuLocale }}
+  {{- end }}
+  {{- if .icuRules }}
+  icuRules: {{ .icuRules }}
+  {{- end }}
+  {{- if .builtinLocale }}
+  builtinLocale: {{ .builtinLocale }}
+  {{- end }}
+  {{- if .collationVersion }}
+  collationVersion: {{ .collationVersion }}
+  {{- end }}
+  {{- if not (kindIs "invalid" .isTemplate) }}
+  isTemplate: {{ .isTemplate }}
+  {{- end }}
+  {{- if not (kindIs "invalid" .allowConnections) }}
+  allowConnections: {{ .allowConnections }}
+  {{- end }}
+  {{- if not (kindIs "invalid" .connectionLimit) }}
+  connectionLimit: {{ .connectionLimit }}
+  {{- end }}
+  {{- if .tablespace }}
+  tablespace: {{ .tablespace }}
+  {{- end }}
+  {{- if .extensions }}
+  extensions: {{- toYaml .extensions | nindent 2 }}
+  {{- end }}
+  {{- if .schemas }}
+  schemas: {{- toYaml .schemas | nindent 2 }}
+  {{- end }}
+  {{- if .fdws }}
+  fdws: {{- toYaml .fdws | nindent 2 }}
+  {{- end }}
+  {{- if .servers }}
+  servers: {{- toYaml .servers | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cnpg-cluster/templates/pg-cluster.yaml
+++ b/charts/cnpg-cluster/templates/pg-cluster.yaml
@@ -77,11 +77,56 @@ spec:
       {{- end }}
   externalClusters:
   - name: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
+    {{- if .Values.backup.legacyMode }}
+    barmanObjectStore:
+      destinationPath: {{ .Values.recovery.destinationPath | default .Values.backup.destinationPath }}
+      endpointURL: {{ .Values.recovery.endpointURL | default .Values.backup.endpointURL }}
+      {{- $useRecoveryCA := or .Values.recovery.endpointCA.create .Values.recovery.endpointCA.secretName }}
+      {{- $useBackupCA := or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+      {{- if or $useRecoveryCA $useBackupCA }}
+      endpointCA:
+        {{- if $useRecoveryCA }}
+        name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
+        key: {{ .Values.recovery.endpointCA.key }}
+        {{- else }}
+        name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+        key: {{ .Values.backup.endpointCA.key }}
+        {{- end }}
+      {{- end }}
+      {{- $useRecoveryCreds := or .Values.recovery.s3Credentials.create .Values.recovery.s3Credentials.secretName }}
+      s3Credentials:
+        accessKeyId:
+          {{- if $useRecoveryCreds }}
+          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+          key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
+          {{- else }}
+          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+          key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+          {{- end }}
+        secretAccessKey:
+          {{- if $useRecoveryCreds }}
+          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+          key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
+          {{- else }}
+          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+          key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+          {{- end }}
+        region:
+          {{- if $useRecoveryCreds }}
+          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+          key: {{ .Values.recovery.s3Credentials.region.key }}
+          {{- else }}
+          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+          key: {{ .Values.backup.s3Credentials.region.key }}
+          {{- end }}
+      serverName: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
+    {{- else }}
     plugin:
       name: barman-cloud.cloudnative-pg.io
       parameters:
-        barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "backup-store" }}
+        barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "recovery-store" }}
         serverName: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
+    {{- end }}
   {{- else if eq .Values.mode "replica" }}
   bootstrap:
     recovery:
@@ -94,11 +139,33 @@ spec:
     source: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
   externalClusters:
   - name: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    {{- if .Values.backup.legacyMode }}
+    barmanObjectStore:
+      destinationPath: {{ .Values.replica.destinationPath }}
+      endpointURL: {{ .Values.replica.endpointURL }}
+      {{- if or .Values.replica.endpointCA.create .Values.replica.endpointCA.secretName }}
+      endpointCA:
+        name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
+        key: {{ .Values.replica.endpointCA.key }}
+      {{- end }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+          key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
+        secretAccessKey:
+          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+          key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
+        region:
+          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+          key: {{ .Values.replica.s3Credentials.region.key }}
+      serverName: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    {{- else }}
     plugin:
       name: barman-cloud.cloudnative-pg.io
       parameters:
         barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "replica-store" }}
         serverName: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    {{- end }}
     {{- if .Values.replica.host }}
     connectionParameters:
       host: {{ .Values.replica.host }}
@@ -108,15 +175,18 @@ spec:
     {{- end }}
   {{- end }}
   {{/* Plugin-based backup and replica configuration (official barman-cloud plugin method) */}}
-  {{- if or (and .Values.backup.enabled (not .Values.backup.legacyMode)) (eq .Values.mode "replica") }}
+  {{- if or (and .Values.backup.enabled (not .Values.backup.legacyMode) (ne .Values.mode "recovery")) (and (eq .Values.mode "replica") (not .Values.backup.legacyMode)) }}
   plugins:
-  {{- if and .Values.backup.enabled (not .Values.backup.legacyMode) }}
+  {{- if and .Values.backup.enabled (not .Values.backup.legacyMode) (ne .Values.mode "recovery") }}
   - name: barman-cloud.cloudnative-pg.io
     isWALArchiver: true
     parameters:
       barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "backup-store" }}
+      {{- range $key, $val := .Values.backup.pluginExtraParameters }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
   {{- end }}
-  {{- if eq .Values.mode "replica" }}
+  {{- if and (eq .Values.mode "replica") (not .Values.backup.legacyMode) }}
   - name: barman-cloud.cloudnative-pg.io
     parameters:
       barmanObjectName: {{ printf "%s-%s" (include "template.fullname" .) "replica-store" }}

--- a/charts/cnpg-cluster/templates/recovery-object-store.yaml
+++ b/charts/cnpg-cluster/templates/recovery-object-store.yaml
@@ -1,0 +1,52 @@
+{{- if and (eq .Values.mode "recovery") (not .Values.backup.legacyMode) }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ printf "%s-%s" (include "template.fullname" .) "recovery-store" }}
+  labels: {{- include "template.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations: {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  configuration:
+    destinationPath: {{ .Values.recovery.destinationPath | default .Values.backup.destinationPath }}
+    endpointURL: {{ .Values.recovery.endpointURL | default .Values.backup.endpointURL }}
+    {{- $useRecoveryCA := or .Values.recovery.endpointCA.create .Values.recovery.endpointCA.secretName }}
+    {{- $useBackupCA := or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+    {{- if or $useRecoveryCA $useBackupCA }}
+    endpointCA:
+      {{- if $useRecoveryCA }}
+      name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
+      key: {{ .Values.recovery.endpointCA.key }}
+      {{- else }}
+      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+      key: {{ .Values.backup.endpointCA.key }}
+      {{- end }}
+    {{- end }}
+    {{- $useRecoveryCreds := or .Values.recovery.s3Credentials.create .Values.recovery.s3Credentials.secretName }}
+    s3Credentials:
+      accessKeyId:
+        {{- if $useRecoveryCreds }}
+        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+        key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
+        {{- else }}
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+        {{- end }}
+      secretAccessKey:
+        {{- if $useRecoveryCreds }}
+        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+        key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
+        {{- else }}
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+        {{- end }}
+      region:
+        {{- if $useRecoveryCreds }}
+        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+        key: {{ .Values.recovery.s3Credentials.region.key }}
+        {{- else }}
+        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+        key: {{ .Values.backup.s3Credentials.region.key }}
+        {{- end }}
+{{- end }}

--- a/charts/cnpg-cluster/templates/replica-object-store.yaml
+++ b/charts/cnpg-cluster/templates/replica-object-store.yaml
@@ -1,8 +1,4 @@
-{{/*
-Plugin-based replica ObjectStore resource.
-Only created in replica mode using the official barman-cloud plugin architecture.
-*/}}
-{{- if eq .Values.mode "replica" }}
+{{- if and (eq .Values.mode "replica") (not .Values.backup.legacyMode) }}
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/charts/cnpg-cluster/templates/scheduled-backup.yaml
+++ b/charts/cnpg-cluster/templates/scheduled-backup.yaml
@@ -1,9 +1,4 @@
-{{/*
-ScheduledBackup resource.
-Uses plugin method when legacyMode is false (default).
-Uses traditional method when legacyMode is true.
-*/}}
-{{- if .Values.backup.enabled }}
+{{- if and .Values.backup.enabled (ne .Values.mode "recovery") }}
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -312,6 +312,252 @@
       "type": "object",
       "description": "Additional specifications to add to the cnpg cluster manifest (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-Cluster)",
       "additionalProperties": true
+    },
+    "databases": {
+      "type": "array",
+      "description": "Declarative database management using the CNPG Database CRD. Each entry creates a Database resource. Not created in replica mode.",
+      "items": {
+        "type": "object",
+        "required": ["name", "owner"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the database inside PostgreSQL (immutable after creation)",
+            "minLength": 1,
+            "not": {
+              "enum": ["postgres", "template0", "template1"]
+            }
+          },
+          "owner": {
+            "type": "string",
+            "description": "Role name of the database owner",
+            "minLength": 1
+          },
+          "ensure": {
+            "type": "string",
+            "enum": ["present", "absent"],
+            "default": "present"
+          },
+          "databaseReclaimPolicy": {
+            "type": "string",
+            "enum": ["retain", "delete"],
+            "default": "retain"
+          },
+          "template": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "localeProvider": {
+            "type": "string"
+          },
+          "localeCollate": {
+            "type": "string"
+          },
+          "localeCType": {
+            "type": "string"
+          },
+          "icuLocale": {
+            "type": "string"
+          },
+          "icuRules": {
+            "type": "string"
+          },
+          "builtinLocale": {
+            "type": "string"
+          },
+          "collationVersion": {
+            "type": "string"
+          },
+          "isTemplate": {
+            "type": "boolean"
+          },
+          "allowConnections": {
+            "type": "boolean"
+          },
+          "connectionLimit": {
+            "type": "integer"
+          },
+          "tablespace": {
+            "type": "string"
+          },
+          "extensions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ensure": {
+                  "type": "string",
+                  "enum": ["present", "absent"],
+                  "default": "present"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "schemas": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "owner"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "owner": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ensure": {
+                  "type": "string",
+                  "enum": ["present", "absent"],
+                  "default": "present"
+                }
+              }
+            }
+          },
+          "fdws": {
+            "type": "array",
+            "description": "Foreign data wrappers to manage",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ensure": {
+                  "type": "string",
+                  "enum": ["present", "absent"],
+                  "default": "present"
+                },
+                "handler": {
+                  "type": "string"
+                },
+                "validator": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name", "value"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "ensure": {
+                        "type": "string",
+                        "enum": ["present", "absent"],
+                        "default": "present"
+                      }
+                    }
+                  }
+                },
+                "usage": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["grant", "revoke"],
+                        "default": "grant"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "servers": {
+            "type": "array",
+            "description": "Foreign servers to manage",
+            "items": {
+              "type": "object",
+              "required": ["name", "fdw"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "ensure": {
+                  "type": "string",
+                  "enum": ["present", "absent"],
+                  "default": "present"
+                },
+                "fdw": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name", "value"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "ensure": {
+                        "type": "string",
+                        "enum": ["present", "absent"],
+                        "default": "present"
+                      }
+                    }
+                  }
+                },
+                "usage": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["grant", "revoke"],
+                        "default": "grant"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -221,6 +221,13 @@
           "type": "boolean",
           "default": true
         },
+        "pluginExtraParameters": {
+          "type": "object",
+          "description": "Extra parameters to pass to the barman-cloud backup plugin (e.g. serverName).",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "destinationPath": {
           "type": "string"
         },

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -421,6 +421,86 @@ monitoring:
     # -- Additional match labels for the podMonitor
     # @section -- Monitoring
     extraMatchLabels: {}
+# Declarative database management using the CNPG Database CRD (postgresql.cnpg.io/v1 Database).
+# Each entry creates a separate Database resource managed by the CNPG operator.
+# Note: Database CRDs are NOT created in replica mode (CNPG limitation).
+# Reserved database names (postgres, template0, template1) cannot be used.
+# @section -- Databases
+databases: []
+  # - # -- Name of the database inside PostgreSQL (required, immutable after creation).
+  #   # @section -- Databases
+  #   name: "mydb"
+  #   # -- Role name of the database owner (required).
+  #   # @section -- Databases
+  #   owner: "myuser"
+  #   # -- Whether the database should be present or absent (default: present).
+  #   # @section -- Databases
+  #   ensure: "present"
+  #   # -- Policy for end-of-life maintenance: retain (default) or delete.
+  #   # @section -- Databases
+  #   databaseReclaimPolicy: "retain"
+  #   # -- Template database name (immutable after creation).
+  #   # @section -- Databases
+  #   template: ""
+  #   # -- Character set encoding (immutable after creation).
+  #   # @section -- Databases
+  #   encoding: ""
+  #   # -- Default collation order and character classification (immutable after creation).
+  #   # @section -- Databases
+  #   locale: ""
+  #   # -- Locale provider: icu or builtin (immutable, available from PostgreSQL 16).
+  #   # @section -- Databases
+  #   localeProvider: ""
+  #   # -- LC_COLLATE setting (immutable after creation).
+  #   # @section -- Databases
+  #   localeCollate: ""
+  #   # -- LC_CTYPE setting (immutable after creation).
+  #   # @section -- Databases
+  #   localeCType: ""
+  #   # -- ICU locale (requires localeProvider=icu, immutable, available from PostgreSQL 15).
+  #   # @section -- Databases
+  #   icuLocale: ""
+  #   # -- Additional ICU collation rules (requires localeProvider=icu, immutable, available from PostgreSQL 16).
+  #   # @section -- Databases
+  #   icuRules: ""
+  #   # -- Builtin locale (requires localeProvider=builtin, immutable, available from PostgreSQL 17).
+  #   # @section -- Databases
+  #   builtinLocale: ""
+  #   # -- Collation version (immutable after creation).
+  #   # @section -- Databases
+  #   collationVersion: ""
+  #   # -- Whether this database is a template (IS_TEMPLATE).
+  #   # @section -- Databases
+  #   isTemplate: false
+  #   # -- Whether connections are allowed (ALLOW_CONNECTIONS).
+  #   # @section -- Databases
+  #   allowConnections: true
+  #   # -- Maximum concurrent connections (-1 means no limit).
+  #   # @section -- Databases
+  #   connectionLimit: -1
+  #   # -- Default tablespace for this database.
+  #   # @section -- Databases
+  #   tablespace: ""
+  #   # -- List of extensions to manage in this database.
+  #   # @section -- Databases
+  #   extensions: []
+  #     # - name: "postgis"
+  #     #   ensure: "present"
+  #     #   version: ""
+  #     #   schema: "public"
+  #   # -- List of schemas to manage in this database.
+  #   # @section -- Databases
+  #   schemas: []
+  #     # - name: "myschema"
+  #     #   owner: "myuser"
+  #     #   ensure: "present"
+  #   # -- List of foreign data wrappers to manage in this database.
+  #   # @section -- Databases
+  #   fdws: []
+  #   # -- List of foreign servers to manage in this database.
+  #   # @section -- Databases
+  #   servers: []
+
 # -- Additional specifications to add to the cnpg cluster manifest (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-Cluster). This allows you to replace any default configuration of the chart and add new configurations that are not yet supported (for example, when a new version of the CNPG is released with new features that are not yet supported).
 # @section -- Database
 extraSpec: {}

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -297,6 +297,11 @@ backup:
   # -- Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration.
   # @section -- Backup
   legacyMode: true
+  # -- Extra parameters to pass to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery).
+  # Only used when `backup.legacyMode` is set to `false`.
+  # @section -- Backup
+  pluginExtraParameters: {}
+  # serverName: "my-cluster-v2"
   # -- S3 destination path for cnpg backups (it should be set like `s3://<bucket_name>/<path>`).
   # @section -- Backup
   destinationPath: ""


### PR DESCRIPTION
## Description

This PR brings several fixes and features to the `cnpg-cluster` chart (v1.7.0):

**Fixes:**
- Disable backup resources (ObjectStore, ScheduledBackup, plugins) during recovery mode to prevent WAL archive collision (`Expected empty archive` error when backup and recovery share the same S3 path).
- Add a separate recovery ObjectStore for plugin mode with a dedicated S3 path.
- Support legacy `barmanObjectStore` in recovery and replica `externalClusters` when `backup.legacyMode` is `true`.
- Guard replica ObjectStore and replica plugin entry behind non-legacy mode.

**Features:**
- Add `backup.pluginExtraParameters` map to pass extra parameters to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery).
- Add declarative database management via the CNPG `Database` CRD (`databases` key in values). Supports extensions, schemas, foreign data wrappers, foreign servers, and all PostgreSQL `CREATE DATABASE` options. Skipped in replica mode (CNPG limitation). Reserved names (`postgres`, `template0`, `template1`) are rejected by schema validation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (typos, code examples or any documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

All 6 mode × legacy combinations validated with `helm template`:

- [x] `mode=primary` + `legacyMode=false` (plugin) — Cluster, ObjectStore, ScheduledBackup, 2×Secret
- [x] `mode=primary` + `legacyMode=true` (legacy) — Cluster, ScheduledBackup, 2×Secret
- [x] `mode=recovery` + `legacyMode=false` (plugin) — Cluster, ObjectStore (recovery only), 2×Secret
- [x] `mode=recovery` + `legacyMode=true` (legacy) — Cluster, 2×Secret
- [x] `mode=replica` + `legacyMode=false` (plugin) — Cluster, 2×ObjectStore, ScheduledBackup, 2×Secret
- [x] `mode=replica` + `legacyMode=true` (legacy) — Cluster, ScheduledBackup, 2×Secret
- [x] `databases` list rendering — Database CRD created in primary/recovery, skipped in replica
- [x] `pluginExtraParameters` rendering in backup plugin configuration

**Test Configuration**:
- Helm: v3
- helm-docs: v1.14.2
- Chart version: 1.7.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings