### PR TITLE
chore(backup-utils): upgrade backup image to v1.1.8

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.3.8
-appVersion: "1.1.7"
+version: 2.3.9
+appVersion: "1.1.8"
 description: Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
 annotations:
@@ -10,7 +10,7 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade backup image to v1.1.7
+      description: Upgrade backup image to v1.1.8
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.3.8](https://img.shields.io/badge/Version-2.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.7](https://img.shields.io/badge/AppVersion-1.1.7-informational?style=flat-square)
+![Version: 2.3.9](https://img.shields.io/badge/Version-2.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.8](https://img.shields.io/badge/AppVersion-1.1.8-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.8
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.9
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.8
+    targetRevision: 2.3.9
     helm:
       releaseName: <release_name>
       values: |
@@ -95,7 +95,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.8
+    targetRevision: 2.3.9
     helm:
       releaseName: <release_name>
       values: |
@@ -120,7 +120,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.8
+  version: 2.3.9
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -130,7 +130,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.8
+  version: 2.3.9
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```


### PR DESCRIPTION
## Description

Upgrades the `backup-utils` Helm chart from version `2.3.8` to `2.3.9`, bumping the backup image `appVersion` from `v1.1.7` to `v1.1.8`. README references have been updated accordingly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (typos, code examples or any documentation update)
- [x] Other (please describe): Dependency / image version bump

## How Has This Been Tested?

Chart linting and template rendering have been validated locally via `helm lint` and `helm template`.

**Test Configuration**:
- Firmware version: N/A
- Hardware: N/A
- Toolchain: Helm 3

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings