### PR TITLE
feat(cnpg-cluster): remove operator dependency and change default backup method

### DIFF
--- a/charts/cnpg-cluster/Chart.lock
+++ b/charts/cnpg-cluster/Chart.lock
@@ -1,6 +1,3 @@
-dependencies:
-- name: cloudnative-pg
-  repository: https://cloudnative-pg.github.io/charts
-  version: 0.27.1
-digest: sha256:2cc056ceea715e55bd1f239fcb46c75020523df0f43bcd94ec9581bf3936e11a
-generated: "2026-02-11T22:59:39.463016+01:00"
+dependencies: []
+digest: sha256:643d5437104296e21d906ecb15b2c96ad278f20cfc4af53b12bb6069bd853726
+generated: "2026-04-16T15:37:17.520455+02:00"

--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 1.7.1
-appVersion: "1.28.1"
+version: 2.0.0
+appVersion: "1.29.0"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io
 deprecated: false
@@ -10,10 +10,10 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Quote `backup.cron` in ScheduledBackup to prevent YAML parsing issues with leading `*` in cron expressions.
     - kind: changed
-      description: Improve README documentation with a dedicated Databases section and properly categorized `logLevel` and `databases` keys.
+      description: Remove CNPG operator dependency.
+    - kind: changed
+      description: Change default backup method to barman-cloud plugin and keep option to use legacy in-tree backup method (deprecated).
 keywords:
 - postgresql
 - postgres
@@ -25,12 +25,7 @@ keywords:
 - backup
 - replication
 - kubernetes
-dependencies:
-- name: cloudnative-pg
-  alias: cnpg-operator
-  version: ">=0.23.0"
-  repository: https://cloudnative-pg.github.io/charts
-  condition: cnpg-operator.enabled
+dependencies: []
 sources:
 - https://github.com/this-is-tobi/helm-charts
 - https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,14 +1,8 @@
 # cnpg-cluster
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.28.1](https://img.shields.io/badge/AppVersion-1.28.1-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
-
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| https://cloudnative-pg.github.io/charts | cnpg-operator(cloudnative-pg) | >=0.23.0 |
 
 ## Installing the Chart
 
@@ -23,7 +17,7 @@ helm install <release_name> tobi/cnpg-cluster
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 1.7.1
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 2.0.0
 ```
 
 ### ArgoCD
@@ -34,7 +28,7 @@ helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster 
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.7.1
+  targetRevision: 2.0.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -47,7 +41,7 @@ sources:
 sources:
 - repoURL: ghcr.io/this-is-tobi/helm-charts
   chart: cnpg-cluster
-  targetRevision: 1.7.1
+  targetRevision: 2.0.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -62,7 +56,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.7.1
+  version: 2.0.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -73,7 +67,7 @@ dependencies:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 1.7.1
+  version: 2.0.0
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -425,7 +419,7 @@ backup-utils:
 | backup.endpointCA.secretName | string | `""` | The secret name containing S3 CA for cnpg backups, leave it empty to auto-generate the secret name. |
 | backup.endpointCA.value | string | `""` | The S3 certificate used for cnpg backups. Only needed if `backup.endpointCA.create` is set to `true`. |
 | backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
-| backup.legacyMode | bool | `true` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
+| backup.legacyMode | bool | `false` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
 | backup.pluginExtraParameters | object | `{}` | Extra parameters to pass to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery). Only used when `backup.legacyMode` is set to `false`. |
 | backup.retentionPolicy | string | `"14d"` | Retention policy for cnpg backups recurrences. |
 | backup.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for cnpg backups. |

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -296,7 +296,7 @@ backup:
   enabled: false
   # -- Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration.
   # @section -- Backup
-  legacyMode: true
+  legacyMode: false
   # -- Extra parameters to pass to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery).
   # Only used when `backup.legacyMode` is set to `false`.
   # @section -- Backup


### PR DESCRIPTION
## Summary

Remove the CNPG operator as a chart dependency and change the default backup method.

## Purpose & Context

**Problem:** The `cnpg-cluster` chart had the CNPG operator declared as a Helm dependency, coupling the cluster chart to the operator lifecycle.
**Solution:** Remove the operator dependency so the chart only manages the cluster resources, and update the default backup method accordingly.

## Changes Made

**`charts/cnpg-cluster`:**
- Remove CNPG operator from `Chart.yaml` dependencies
- Update `Chart.lock` to reflect removed dependency
- Change default backup method in `values.yaml`

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No breaking changes (or documented)
- [ ] Self-reviewed the code
- [ ] Ready for review