### PR TITLE
chore(backup-utils): upgrade backup image to v1.1.9

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.3.9
-appVersion: "1.1.8"
+version: 2.3.10
+appVersion: "1.1.9"
 description: Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
 annotations:
@@ -10,7 +10,7 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade backup image to v1.1.8
+      description: Upgrade backup image to v1.1.9
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.3.9](https://img.shields.io/badge/Version-2.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.8](https://img.shields.io/badge/AppVersion-1.1.8-informational?style=flat-square)
+![Version: 2.3.10](https://img.shields.io/badge/Version-2.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.9](https://img.shields.io/badge/AppVersion-1.1.9-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.9
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.3.10
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.9
+    targetRevision: 2.3.10
     helm:
       releaseName: <release_name>
       values: |
@@ -95,7 +95,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.3.9
+    targetRevision: 2.3.10
     helm:
       releaseName: <release_name>
       values: |
@@ -120,7 +120,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.9
+  version: 2.3.10
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -130,7 +130,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.3.9
+  version: 2.3.10
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```


### PR DESCRIPTION
## Summary

Upgrade the `backup-utils` chart to use backup image v1.1.9.

## Changes Made

**chart/backup-utils:**
- Bump `appVersion` from `1.1.8` to `1.1.9`
- Bump chart `version` from `2.3.9` to `2.3.10`
- Update `README.md` version badges and all version references

## Checklist

- [x] No breaking changes
- [x] Documentation updated (README.md)
- [x] Self-reviewed the code