### PR TITLE
feat(vso-utils)!: replace tls block with caCertSecretRef, caCertPath, and tlsServerName in VaultConnection (v2.0.0)

### DIFF
--- a/charts/vso-utils/Chart.yaml
+++ b/charts/vso-utils/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vso-utils
 type: application
-version: 1.1.7
+version: 2.0.0
 appVersion: "1.3.0"
 description: Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 deprecated: false
@@ -10,7 +10,7 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgraded vault-secrets-operator dependency to 1.3.0
+      description: "BREAKING: replace tls nested block with flat caCertSecretRef, caCertPath, and tlsServerName fields in VaultConnection"
 keywords:
 - vault
 - secrets

--- a/charts/vso-utils/README.md
+++ b/charts/vso-utils/README.md
@@ -1,6 +1,6 @@
 # vso-utils
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Production-ready Helm chart for managing HashiCorp Vault Secret Operator resources - sync static secrets, generate dynamic credentials, issue PKI certificates, and configure Vault authentication.
 
@@ -50,7 +50,7 @@ helm install <release_name> tobi/vso-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 1.1.7
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/vso-utils --version 2.0.0
 ```
 
 ### ArgoCD
@@ -66,7 +66,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.7
+    targetRevision: 2.0.0
     helm:
       releaseName: <release_name>
       values: |
@@ -93,7 +93,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: vso-utils
-    targetRevision: 1.1.7
+    targetRevision: 2.0.0
     helm:
       releaseName: <release_name>
       values: |
@@ -116,7 +116,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.7
+  version: 2.0.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: vso-utils.enabled
 ```
@@ -126,7 +126,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: vso-utils
-  version: 1.1.7
+  version: 2.0.0
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: vso-utils.enabled
 ```
@@ -235,8 +235,7 @@ vaultConnection:
   default:
     address: https://vault.example.com:8200
     skipTLSVerify: false
-    tls:
-      caCertSecretRef: vault-ca-cert
+    caCertSecretRef: vault-ca-cert
 
 vaultAuth:
   default:

--- a/charts/vso-utils/README.md.gotmpl
+++ b/charts/vso-utils/README.md.gotmpl
@@ -233,8 +233,7 @@ vaultConnection:
   default:
     address: https://vault.example.com:8200
     skipTLSVerify: false
-    tls:
-      caCertSecretRef: vault-ca-cert
+    caCertSecretRef: vault-ca-cert
 
 vaultAuth:
   default:

--- a/charts/vso-utils/templates/vault-connection.yaml
+++ b/charts/vso-utils/templates/vault-connection.yaml
@@ -17,9 +17,14 @@ spec:
   headers:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with $conn.tls }}
-  tls:
-    {{- toYaml . | nindent 4 }}
+  {{- with $conn.caCertSecretRef }}
+  caCertSecretRef: {{ . }}
+  {{- end }}
+  {{- with $conn.caCertPath }}
+  caCertPath: {{ . }}
+  {{- end }}
+  {{- with $conn.tlsServerName }}
+  tlsServerName: {{ . }}
   {{- end }}
   {{- if hasKey $conn "skipTLSVerify" }}
   skipTLSVerify: {{ $conn.skipTLSVerify }}

--- a/charts/vso-utils/values.schema.json
+++ b/charts/vso-utils/values.schema.json
@@ -266,12 +266,9 @@
           "labels": { "type": "object" },
           "address": { "type": "string" },
           "headers": { "type": "object" },
-          "tls": {
-            "type": "object",
-            "properties": {
-              "caCertSecretRef": { "type": "string" }
-            }
-          },
+          "caCertSecretRef": { "type": "string" },
+          "caCertPath": { "type": "string" },
+          "tlsServerName": { "type": "string" },
           "skipTLSVerify": { "type": "boolean", "default": false },
           "timeout": { "type": "string", "default": "60s" }
         }

--- a/charts/vso-utils/values.yaml
+++ b/charts/vso-utils/values.yaml
@@ -287,10 +287,12 @@ vaultConnection: {}
   #   address: "https://vault.example.com:8200"
   #   # -- Headers to include in all Vault requests.
   #   headers: {}
-  #   # -- TLS configuration for Vault connection.
-  #   tls:
-  #     # -- CA certificate for verifying Vault server.
-  #     caCertSecretRef: "vault-ca-cert"
+  #   # -- Name of a Kubernetes Secret containing a PEM-encoded CA certificate chain (key: ca.crt).
+  #   caCertSecretRef: ""
+  #   # -- Path to a PEM CA cert file on the pod filesystem.
+  #   caCertPath: ""
+  #   # -- TLS server name to use for verification.
+  #   tlsServerName: ""
   #   # -- Skip TLS verification (not recommended for production).
   #   skipTLSVerify: false
   #   # -- Timeout for Vault requests.

--- a/template/README.md
+++ b/template/README.md
@@ -137,6 +137,7 @@ A Helm chart to deploy chartname.
 | servicename.metrics.service.annotations | object | `{}` | Metrics service annotations. |
 | servicename.metrics.service.labels | object | `{}` | Metrics service labels. |
 | servicename.metrics.service.port | int | `9000` | Metrics service port. |
+| servicename.metrics.service.portName | string | `"metrics"` | Metrics service port name. |
 | servicename.metrics.service.targetPort | int | `9000` | Metrics service target port. |
 | servicename.metrics.serviceMonitor.annotations | object | `{}` | Prometheus ServiceMonitor annotations. |
 | servicename.metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor. |


### PR DESCRIPTION
## Summary

Replace the invalid `tls:` nested block in the `VaultConnection` template with the flat spec fields the CRD actually supports.

## Purpose & Context

**Problem:** The `vault-connection.yaml` template rendered a `tls:` block that maps to no real field in the `VaultConnection` CRD (`secrets.hashicorp.com/v1beta1`). The value was always silently ignored by the operator. Consumers had no valid path to supply a trusted CA cert.

**Solution:** Replace the bogus `tls:` block with the three flat fields the CRD exposes: `caCertSecretRef`, `caCertPath`, and `tlsServerName`. Update schema, values comments, and docs accordingly.

## Changes Made

**`charts/vso-utils/templates/vault-connection.yaml`:**
- Remove `{{- with $conn.tls }}` block
- Add conditional rendering for `caCertSecretRef`, `caCertPath`, and `tlsServerName`

**`charts/vso-utils/values.schema.json`:**
- Replace `tls` object property with three flat string properties: `caCertSecretRef`, `caCertPath`, `tlsServerName`

**`charts/vso-utils/values.yaml`:**
- Update `vaultConnection` example comments to document the three new flat fields

**`charts/vso-utils/README.md.gotmpl` / `README.md`:**
- Update the complete setup example to use `caCertSecretRef` at the top level instead of nested under `tls:`

**`charts/vso-utils/Chart.yaml`:**
- Bump version `1.1.7` → `2.0.0` (breaking change)
- Update `artifacthub.io/changes` annotation

## Breaking Changes

⚠️ Any consumer using `vaultConnection.<name>.tls.caCertSecretRef` must flatten the field:

```yaml
# Before (never worked — was silently ignored by the CRD)
vaultConnection:
  default:
    tls:
      caCertSecretRef: vault-ca

# After
vaultConnection:
  default:
    caCertSecretRef: vault-ca
```

## Additional Notes

After this release, consumers can flip `skipTLSVerify: false` and supply a `caCertSecretRef` pointing to a Kubernetes Secret with a `ca.crt` PEM chain to get proper Vault TLS verification.