### PR TITLE
fix(backup-utils): remove wrong rclone flag in scripts

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.5.1
-appVersion: "1.3.1"
+version: 2.5.2
+appVersion: "1.3.2"
 description: Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, MongoDB, etcd, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
 annotations:
@@ -10,9 +10,9 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade backup image to v1.3.1
+      description: Upgrade backup image to v1.3.2
     - kind: fixed
-      description: Avoid rclone bucket creation by default, add option to create bucket
+      description: Remove wrong rclone flag in scripts
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 2.5.2](https://img.shields.io/badge/Version-2.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, MongoDB, etcd, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -52,7 +52,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.5.1
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.5.2
 ```
 
 ### ArgoCD
@@ -68,7 +68,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.5.1
+    targetRevision: 2.5.2
     helm:
       releaseName: <release_name>
       values: |
@@ -97,7 +97,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.5.1
+    targetRevision: 2.5.2
     helm:
       releaseName: <release_name>
       values: |
@@ -122,7 +122,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.5.1
+  version: 2.5.2
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -132,7 +132,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.5.1
+  version: 2.5.2
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```


### PR DESCRIPTION
## Description

Remove unknown flag in the backup-utils chart. This fixes the issue where rclone would attempt to add an unknown no create buckets flag.

<!-- If needed link the issue fixed by this PR -->
<!-- Fixes # -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (typos, code examples or any documentation update)
- [ ] Other (please describe):

## How Has This Been Tested?

The change was tested by installing the chart with default values and verifying that no bucket creation attempt occurs. Manual inspection of the generated rclone command confirmed the omission.

**Test Configuration**:
- Firmware version: N/A
- Hardware: N/A
- Toolchain: Helm 3.12, Kubernetes 1.27

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings