### PR TITLE
feat: add backup.encryption/jobs/maxParallel and ObjectStore extraSpec; update backup-utils

### DIFF
--- a/charts/backup-utils/Chart.yaml
+++ b/charts/backup-utils/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: backup-utils
 type: application
-version: 2.5.3
-appVersion: "1.3.4"
+version: 2.5.4
+appVersion: "1.4.0"
 description: Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, MongoDB, etcd, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 deprecated: false
 annotations:
@@ -10,7 +10,7 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade backup image to v1.3.4
+      description: Upgrade backup image to v1.4.0
 keywords:
 - backup
 - postgresql

--- a/charts/backup-utils/README.md
+++ b/charts/backup-utils/README.md
@@ -1,6 +1,6 @@
 # backup-utils
 
-![Version: 2.5.3](https://img.shields.io/badge/Version-2.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.4](https://img.shields.io/badge/AppVersion-1.3.4-informational?style=flat-square)
+![Version: 2.5.4](https://img.shields.io/badge/Version-2.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Production-ready Helm chart for automated backups of PostgreSQL, MariaDB, MongoDB, etcd, Vault, Qdrant, and S3 buckets to S3-compatible storage with configurable schedules and retention policies.
 
@@ -52,7 +52,7 @@ helm install <release_name> tobi/backup-utils
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.5.3
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/backup-utils --version 2.5.4
 ```
 
 ### ArgoCD
@@ -68,7 +68,7 @@ spec:
   sources:
   - repoURL: https://this-is-tobi.github.io/helm-charts
     chart: backup-utils
-    targetRevision: 2.5.3
+    targetRevision: 2.5.4
     helm:
       releaseName: <release_name>
       values: |
@@ -97,7 +97,7 @@ spec:
   sources:
   - repoURL: ghcr.io/this-is-tobi/helm-charts
     chart: backup-utils
-    targetRevision: 2.5.3
+    targetRevision: 2.5.4
     helm:
       releaseName: <release_name>
       values: |
@@ -122,7 +122,7 @@ spec:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.5.3
+  version: 2.5.4
   repository: https://this-is-tobi.github.io/helm-charts
   condition: backup-utils.enabled
 ```
@@ -132,7 +132,7 @@ dependencies:
 # Chart.yaml
 dependencies:
 - name: backup-utils
-  version: 2.5.3
+  version: 2.5.4
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: backup-utils.enabled
 ```

--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: "1.29.0"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io
@@ -10,10 +10,12 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: changed
-      description: Let the CNPG operator manage credential secrets by default instead of generating them in the chart. This prevents password rotation on helm upgrade and works seamlessly with ArgoCD/GitOps.
+    - kind: added
+      description: Add `backup.encryption`, `backup.jobs` and `backup.maxParallel` values to configure barman-cloud data/WAL backup encryption and parallelism (applies to both the barman-cloud plugin ObjectStore and the legacy in-tree `barmanObjectStore` configuration).
+    - kind: added
+      description: Add `backup.extraSpec`, `recovery.extraSpec` and `replica.extraSpec` values to merge extra fields (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) into the barman-cloud plugin ObjectStore CRs that are not otherwise exposed by this chart.
     - kind: fixed
-      description: Preserve newline before YAML document separator in pg-cluster-secrets template.
+      description: Fix `backup.legacyMode` default in values.schema.json to match the chart's actual default of `false`.
 keywords:
 - postgresql
 - postgres

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 
@@ -17,7 +17,7 @@ helm install <release_name> tobi/cnpg-cluster
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 2.1.0
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 2.2.0
 ```
 
 ### ArgoCD
@@ -28,7 +28,7 @@ helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster 
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 2.1.0
+  targetRevision: 2.2.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -41,7 +41,7 @@ sources:
 sources:
 - repoURL: ghcr.io/this-is-tobi/helm-charts
   chart: cnpg-cluster
-  targetRevision: 2.1.0
+  targetRevision: 2.2.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -56,7 +56,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 2.1.0
+  version: 2.2.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -67,7 +67,7 @@ dependencies:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 2.1.0
+  version: 2.2.0
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -524,12 +524,16 @@ backup-utils:
 | backup.cron | string | `"0 0 */6 * * *"` | The cron rule used for cnpg backups. By default it runs every 6 hours. |
 | backup.destinationPath | string | `""` | S3 destination path for cnpg backups (it should be set like `s3://<bucket_name>/<path>`). |
 | backup.enabled | bool | `false` | Whether or not cnpg cluster backup should be enabled. |
+| backup.encryption | string | `""` | Encryption algorithm for backups (e.g., AES256). Leave blank to disable encryption. |
 | backup.endpointCA.create | bool | `false` | Whether or not to create S3 CA kubernetes secret used for cnpg backups. It will use `secretName`, `endpointCA.key` and `endpointCA.value` to create the secret. |
 | backup.endpointCA.key | string | `"ca.crt"` | The secret key containing S3 CA for cnpg backups. |
 | backup.endpointCA.secretName | string | `""` | The secret name containing S3 CA for cnpg backups, leave it empty to auto-generate the secret name. |
 | backup.endpointCA.value | string | `""` | The S3 certificate used for cnpg backups. Only needed if `backup.endpointCA.create` is set to `true`. |
 | backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
+| backup.extraSpec | object | `{}` | Extra spec fields merged into the ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) for fields not explicitly exposed by this chart. Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
+| backup.jobs | int | `1` | Number of parallel backup jobs. |
 | backup.legacyMode | bool | `false` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
+| backup.maxParallel | int | `1` | Maximum parallel WAL processing during backup. |
 | backup.pluginExtraParameters | object | `{}` | Extra parameters to pass to the barman-cloud backup plugin (e.g. `serverName` to isolate WAL paths when reusing the same S3 bucket after a recovery). Only used when `backup.legacyMode` is set to `false`. |
 | backup.retentionPolicy | string | `"14d"` | Retention policy for cnpg backups recurrences. |
 | backup.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for cnpg backups. |
@@ -634,6 +638,7 @@ backup-utils:
 | recovery.endpointCA.value | string | `""` | The S3 certificate used for recovery mode. Only needed if `recovery.endpointCA.create` is set to `true`. |
 | recovery.endpointURL | string | `""` | S3 endpoint used for recovery mode. |
 | recovery.extraArgs | object | `{}` | Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB). |
+| recovery.extraSpec | object | `{}` | Extra spec fields merged into the recovery ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
 | recovery.maxParallelWal | int | `8` | The number of parallel process that will be applied when applying wals. |
 | recovery.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for recovery mode. |
 | recovery.s3Credentials.accessKeyId.value | string | `""` | S3 accessKeyId value used for recovery mode. Only needed if `recovery.s3Credentials.create` is set to `true`. |
@@ -657,6 +662,7 @@ backup-utils:
 | replica.endpointCA.value | string | `""` | The S3 certificate used for replica mode. Only needed if `replica.endpointCA.create` is set to `true`. |
 | replica.endpointURL | string | `""` | S3 endpoint used for replica mode. |
 | replica.extraArgs | object | `{}` | Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB). |
+| replica.extraSpec | object | `{}` | Extra spec fields merged into the replica ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
 | replica.host | string | `""` | Primary cnpg cluster host used for replica mode. |
 | replica.maxParallelWal | int | `8` | The number of parallel process that will be applied when applying wals. |
 | replica.port | int | `5432` | Primary cnpg cluster port used for replica mode. |

--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -152,11 +152,29 @@ backup:
       region:
         name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
         key: {{ .Values.backup.s3Credentials.region.key }}
-    {{- if .Values.backup.compression }}
+    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.jobs }}
     data:
+      {{- if .Values.backup.compression }}
       compression: {{ .Values.backup.compression }}
+      {{- end }}
+      {{- if .Values.backup.encryption }}
+      encryption: {{ .Values.backup.encryption }}
+      {{- end }}
+      {{- if .Values.backup.jobs }}
+      jobs: {{ .Values.backup.jobs }}
+      {{- end }}
+    {{- end }}
+    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.maxParallel }}
     wal:
+      {{- if .Values.backup.compression }}
       compression: {{ .Values.backup.compression }}
+      {{- end }}
+      {{- if .Values.backup.encryption }}
+      encryption: {{ .Values.backup.encryption }}
+      {{- end }}
+      {{- if .Values.backup.maxParallel }}
+      maxParallel: {{ .Values.backup.maxParallel }}
+      {{- end }}
     {{- end }}
   retentionPolicy: {{ .Values.backup.retentionPolicy }}
 {{- end }}

--- a/charts/cnpg-cluster/templates/backup-object-store.yaml
+++ b/charts/cnpg-cluster/templates/backup-object-store.yaml
@@ -26,11 +26,32 @@ spec:
       region:
         name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
         key: {{ .Values.backup.s3Credentials.region.key }}
-    {{- if .Values.backup.compression }}
+    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.jobs }}
     data:
+      {{- if .Values.backup.compression }}
       compression: {{ .Values.backup.compression }}
+      {{- end }}
+      {{- if .Values.backup.encryption }}
+      encryption: {{ .Values.backup.encryption }}
+      {{- end }}
+      {{- if .Values.backup.jobs }}
+      jobs: {{ .Values.backup.jobs }}
+      {{- end }}
+    {{- end }}
+    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.maxParallel }}
     wal:
+      {{- if .Values.backup.compression }}
       compression: {{ .Values.backup.compression }}
+      {{- end }}
+      {{- if .Values.backup.encryption }}
+      encryption: {{ .Values.backup.encryption }}
+      {{- end }}
+      {{- if .Values.backup.maxParallel }}
+      maxParallel: {{ .Values.backup.maxParallel }}
+      {{- end }}
     {{- end }}
   retentionPolicy: {{ .Values.backup.retentionPolicy }}
+  {{- with .Values.backup.extraSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/cnpg-cluster/templates/recovery-object-store.yaml
+++ b/charts/cnpg-cluster/templates/recovery-object-store.yaml
@@ -49,4 +49,7 @@ spec:
         name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
         key: {{ .Values.backup.s3Credentials.region.key }}
         {{- end }}
+  {{- with .Values.recovery.extraSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/cnpg-cluster/templates/replica-object-store.yaml
+++ b/charts/cnpg-cluster/templates/replica-object-store.yaml
@@ -26,4 +26,7 @@ spec:
       region:
         name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
         key: {{ .Values.replica.s3Credentials.region.key }}
+  {{- with .Values.replica.extraSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -219,7 +219,7 @@
         },
         "legacyMode": {
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "pluginExtraParameters": {
           "type": "object",
@@ -227,6 +227,72 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "endpointCA": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to create a Kubernetes secret for the S3 CA."
+            },
+            "secretName": {
+              "type": "string",
+              "description": "Name of the secret containing the S3 CA."
+            },
+            "key": {
+              "type": "string",
+              "description": "Key within the secret that holds the CA certificate."
+            }
+          }
+        },
+        "s3Credentials": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to create a Kubernetes secret for S3 credentials."
+            },
+            "secretName": {
+              "type": "string",
+              "description": "Name of the secret containing S3 credentials."
+            },
+            "accessKeyId": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string", "description": "Key in the secret for the access key ID." }
+              }
+            },
+            "secretAccessKey": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string", "description": "Key in the secret for the secret access key." }
+              }
+            },
+            "region": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string", "description": "Key in the secret for the region." }
+              }
+            }
+          }
+        },
+        "compression": {
+          "type": "string",
+          "description": "Compression algorithm for backups (gzip, bzip2, snappy). Empty disables compression."
+        },
+        "encryption": {
+          "type": "string",
+          "description": "Encryption algorithm for backups (e.g., AES256). Empty disables encryption."
+        },
+        "jobs": {
+          "type": "integer",
+          "description": "Number of parallel backup jobs."
+        },
+        "maxParallel": {
+          "type": "integer",
+          "description": "Maximum parallel WAL processing during backup."
         },
         "destinationPath": {
           "type": "string"
@@ -240,6 +306,10 @@
         "cron": {
           "type": "string",
           "description": "Cron expression for scheduled backups (quoted to handle leading `*`)."
+        },
+        "extraSpec": {
+          "type": "object",
+          "description": "Extra spec fields merged into the ObjectStore CR (e.g. serverName, tags, historyTags, instanceSidecarConfiguration)."
         }
       }
     },
@@ -251,6 +321,10 @@
         },
         "endpointURL": {
           "type": "string"
+        },
+        "extraSpec": {
+          "type": "object",
+          "description": "Extra spec fields merged into the recovery ObjectStore CR."
         }
       }
     },
@@ -282,6 +356,10 @@
           "type": "string",
           "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
           "default": "prefer"
+        },
+        "extraSpec": {
+          "type": "object",
+          "description": "Extra spec fields merged into the replica ObjectStore CR."
         }
       }
     },

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -184,6 +184,9 @@ recovery:
     # recoveryTarget:
     #   backupID: 20250214T120000
     #   targetImmediate: true
+  # -- Extra spec fields merged into the recovery ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
+  # @section -- Recovery mode
+  extraSpec: {}
 replica:
   # -- S3 destination path used for replica mode (it should be set like `s3://<bucket_name>/<path>`).
   # @section -- Replica mode
@@ -260,6 +263,9 @@ replica:
   # -- Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB).
   # @section -- Replica mode
   extraArgs: {}
+  # -- Extra spec fields merged into the replica ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
+  # @section -- Replica mode
+  extraSpec: {}
 infosSecret:
   # -- Whether or not to create an infos secret containing database connection information (host, port, database name, username, password, and connection string). Only effective when `credentials.password` is set (chart-managed credentials). When credentials are operator-managed, use the operator-generated `<cluster>-app` secret directly.
   # @section -- Database
@@ -358,12 +364,24 @@ backup:
   # -- Which compression algorithm should be used for cnpg backups (should be one of "gzip", "bzip2" or "snappy"), leave blank to disable compression.
   # @section -- Backup
   compression: ""
+  # -- Encryption algorithm for backups (e.g., AES256). Leave blank to disable encryption.
+  # @section -- Backup
+  encryption: ""
+  # -- Number of parallel backup jobs.
+  # @section -- Backup
+  jobs: 1
+  # -- Maximum parallel WAL processing during backup.
+  # @section -- Backup
+  maxParallel: 1
   # -- The cron rule used for cnpg backups. By default it runs every 6 hours.
   # @section -- Backup
   cron: "0 0 */6 * * *"
   # -- Retention policy for cnpg backups recurrences.
   # @section -- Backup
   retentionPolicy: "14d"
+  # -- Extra spec fields merged into the ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) for fields not explicitly exposed by this chart. Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
+  # @section -- Backup
+  extraSpec: {}
 resources:
   requests:
     # -- Memory request for the database instance.


### PR DESCRIPTION
## Description

Comprehensive updates to both `cnpg-cluster` and `backup-utils` charts:

### cnpg-cluster (v2.2.0)
- Add `backup.encryption`, `backup.jobs`, `backup.maxParallel` to configure barman-cloud data/WAL backup encryption and parallelism (applies to both plugin ObjectStore and legacy in-tree `barmanObjectStore` configuration).
- Add `backup.extraSpec`, `recovery.extraSpec`, `replica.extraSpec` to merge additional fields (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) into the barman-cloud plugin `ObjectStore` CRs that are not otherwise explicitly modeled by the chart.
- Fix `backup.legacyMode` default in `values.schema.json` to match the chart's actual default of `false`.
- Regenerate auto-generated documentation via `helm-docs`.

### backup-utils
- Update Chart metadata and regenerate README.

Both charts pass `helm lint` validation and template rendering smoke tests.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (typos, code examples or any documentation update)

## How Has This Been Tested?

- Ran `helm lint` for all charts in the repo
- Ran `helm template` with `backup.enabled=true`, `backup.legacyMode=false`, and ObjectStore extraSpec values to validate correct rendering
- Full render smoke test: `helm template test charts/cnpg-cluster --set backup.enabled=true --set backup.legacyMode=false --set backup.destinationPath=s3://bucket/path --set backup.endpointURL=https://s3.example.com`

**Test Configuration**:
- Helm: v3
- All linters passed

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
