### PR TITLE
feat(cnpg-cluster): add barman additionalCommandArgs and extraConfiguration values

### DIFF
--- a/charts/cnpg-cluster/Chart.yaml
+++ b/charts/cnpg-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cnpg-cluster
 type: application
-version: 2.2.1
+version: 2.3.0
 appVersion: "1.29.0"
 description: A Helm Chart to deploy easily a CNPG cluster
 home: https://cloudnative-pg.io
@@ -10,8 +10,10 @@ annotations:
   artifacthub.io/category: database
   artifacthub.io/license: MIT
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Remove podMonitor template that conflict with CNPG operator management.
+    - kind: added
+      description: Add backup.dataAdditionalCommandArgs and backup.walAdditionalCommandArgs to pass extra arguments to barman-cloud-backup and barman-cloud-wal-archive (e.g. --min-chunk-size to avoid the S3 1000 multipart chunks limit).
+    - kind: added
+      description: Add backup/recovery/replica extraConfiguration values deep-merged into the barman object store configuration to support any field not explicitly exposed by the chart.
 keywords:
 - postgresql
 - postgres

--- a/charts/cnpg-cluster/README.md
+++ b/charts/cnpg-cluster/README.md
@@ -1,6 +1,6 @@
 # cnpg-cluster
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.29.0](https://img.shields.io/badge/AppVersion-1.29.0-informational?style=flat-square)
 
 A Helm Chart to deploy easily a CNPG cluster
 
@@ -17,7 +17,7 @@ helm install <release_name> tobi/cnpg-cluster
 
 **Using OCI Registry (Recommended):**
 ```sh
-helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 2.2.1
+helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster --version 2.3.0
 ```
 
 ### ArgoCD
@@ -28,7 +28,7 @@ helm install <release_name> oci://ghcr.io/this-is-tobi/helm-charts/cnpg-cluster 
 sources:
 - repoURL: https://this-is-tobi.github.io/helm-charts
   chart: cnpg-cluster
-  targetRevision: 2.2.1
+  targetRevision: 2.3.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -41,7 +41,7 @@ sources:
 sources:
 - repoURL: ghcr.io/this-is-tobi/helm-charts
   chart: cnpg-cluster
-  targetRevision: 2.2.1
+  targetRevision: 2.3.0
   helm:
     releaseName: <release_name>
     parameters: []
@@ -56,7 +56,7 @@ sources:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 2.2.1
+  version: 2.3.0
   repository: https://this-is-tobi.github.io/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -67,7 +67,7 @@ dependencies:
 [...]
 dependencies:
 - name: cnpg-cluster
-  version: 2.2.1
+  version: 2.3.0
   repository: oci://ghcr.io/this-is-tobi/helm-charts
   condition: cnpg-cluster.enabled
 ```
@@ -522,6 +522,7 @@ backup-utils:
 |-----|------|---------|-------------|
 | backup.compression | string | `""` | Which compression algorithm should be used for cnpg backups (should be one of "gzip", "bzip2" or "snappy"), leave blank to disable compression. |
 | backup.cron | string | `"0 0 */6 * * *"` | The cron rule used for cnpg backups. By default it runs every 6 hours. |
+| backup.dataAdditionalCommandArgs | list | `[]` | Additional command line arguments passed to `barman-cloud-backup` (e.g. `["--min-chunk-size=100MB"]` to stay under the S3 limit of 1000 multipart upload chunks on large backups). |
 | backup.destinationPath | string | `""` | S3 destination path for cnpg backups (it should be set like `s3://<bucket_name>/<path>`). |
 | backup.enabled | bool | `false` | Whether or not cnpg cluster backup should be enabled. |
 | backup.encryption | string | `""` | Encryption algorithm for backups (e.g., AES256). Leave blank to disable encryption. |
@@ -530,6 +531,7 @@ backup-utils:
 | backup.endpointCA.secretName | string | `""` | The secret name containing S3 CA for cnpg backups, leave it empty to auto-generate the secret name. |
 | backup.endpointCA.value | string | `""` | The S3 certificate used for cnpg backups. Only needed if `backup.endpointCA.create` is set to `true`. |
 | backup.endpointURL | string | `""` | S3 endpoint for cnpg backups. |
+| backup.extraConfiguration | object | `{}` | Extra fields deep-merged into the barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `tags`, `historyTags`, `data.immediateCheckpoint`, `wal.restoreAdditionalCommandArgs`, `azureCredentials`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration). |
 | backup.extraSpec | object | `{}` | Extra spec fields merged into the ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) for fields not explicitly exposed by this chart. Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
 | backup.jobs | int | `1` | Number of parallel backup jobs. |
 | backup.legacyMode | bool | `false` | Use legacy in-tree backup method instead of barman-cloud plugin (deprecated, will be removed in future CNPG versions). When `false` (recommended), uses the official barman-cloud plugin with ObjectStore CRD. When `true`, falls back to the deprecated in-tree barmanObjectStore configuration. |
@@ -544,6 +546,7 @@ backup-utils:
 | backup.s3Credentials.secretAccessKey.key | string | `"secretAccessKey"` | S3 secretAccessKey kubernetes secret key used for cnpg backups. |
 | backup.s3Credentials.secretAccessKey.value | string | `""` | S3 secretAccessKey value used for cnpg backups. Only needed if `backup.s3Credentials.create` is set to `true`. |
 | backup.s3Credentials.secretName | string | `""` | S3 kubernetes secret name used for cnpg backups, leave it empty to auto-generate the secret name. |
+| backup.walAdditionalCommandArgs | list | `[]` | Additional command line arguments passed to `barman-cloud-wal-archive` (e.g. `["--read-timeout=60"]`). |
 
 ### Database
 
@@ -638,6 +641,7 @@ backup-utils:
 | recovery.endpointCA.value | string | `""` | The S3 certificate used for recovery mode. Only needed if `recovery.endpointCA.create` is set to `true`. |
 | recovery.endpointURL | string | `""` | S3 endpoint used for recovery mode. |
 | recovery.extraArgs | object | `{}` | Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB). |
+| recovery.extraConfiguration | object | `{}` | Extra fields deep-merged into the recovery barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `wal.maxParallel`, `wal.restoreAdditionalCommandArgs`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration). |
 | recovery.extraSpec | object | `{}` | Extra spec fields merged into the recovery ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
 | recovery.maxParallelWal | int | `8` | The number of parallel process that will be applied when applying wals. |
 | recovery.s3Credentials.accessKeyId.key | string | `"accessKeyId"` | S3 accessKeyId kubernetes secret key used for recovery mode. |
@@ -662,6 +666,7 @@ backup-utils:
 | replica.endpointCA.value | string | `""` | The S3 certificate used for replica mode. Only needed if `replica.endpointCA.create` is set to `true`. |
 | replica.endpointURL | string | `""` | S3 endpoint used for replica mode. |
 | replica.extraArgs | object | `{}` | Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB). |
+| replica.extraConfiguration | object | `{}` | Extra fields deep-merged into the replica barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `wal.maxParallel`, `wal.restoreAdditionalCommandArgs`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration). |
 | replica.extraSpec | object | `{}` | Extra spec fields merged into the replica ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec). |
 | replica.host | string | `""` | Primary cnpg cluster host used for replica mode. |
 | replica.maxParallelWal | int | `8` | The number of parallel process that will be applied when applying wals. |

--- a/charts/cnpg-cluster/templates/_helpers.tpl
+++ b/charts/cnpg-cluster/templates/_helpers.tpl
@@ -127,6 +127,144 @@ operator
 {{- end -}}
 
 {{/*
+Barman object store configuration for the backup store.
+Shared between the plugin ObjectStore CR (spec.configuration) and the legacy in-tree barmanObjectStore.
+*/}}
+{{- define "template.backup.storeConfiguration" -}}
+destinationPath: {{ .Values.backup.destinationPath }}
+endpointURL: {{ .Values.backup.endpointURL }}
+{{- if or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+endpointCA:
+  name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+  key: {{ .Values.backup.endpointCA.key }}
+{{- end }}
+s3Credentials:
+  accessKeyId:
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+  secretAccessKey:
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+  region:
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.region.key }}
+{{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.jobs .Values.backup.dataAdditionalCommandArgs }}
+data:
+  {{- if .Values.backup.compression }}
+  compression: {{ .Values.backup.compression }}
+  {{- end }}
+  {{- if .Values.backup.encryption }}
+  encryption: {{ .Values.backup.encryption }}
+  {{- end }}
+  {{- if .Values.backup.jobs }}
+  jobs: {{ .Values.backup.jobs }}
+  {{- end }}
+  {{- if .Values.backup.dataAdditionalCommandArgs }}
+  additionalCommandArgs: {{- toYaml .Values.backup.dataAdditionalCommandArgs | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.maxParallel .Values.backup.walAdditionalCommandArgs }}
+wal:
+  {{- if .Values.backup.compression }}
+  compression: {{ .Values.backup.compression }}
+  {{- end }}
+  {{- if .Values.backup.encryption }}
+  encryption: {{ .Values.backup.encryption }}
+  {{- end }}
+  {{- if .Values.backup.maxParallel }}
+  maxParallel: {{ .Values.backup.maxParallel }}
+  {{- end }}
+  {{- if .Values.backup.walAdditionalCommandArgs }}
+  additionalCommandArgs: {{- toYaml .Values.backup.walAdditionalCommandArgs | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Barman object store configuration for the recovery store (with fallback to backup settings).
+Shared between the plugin ObjectStore CR (spec.configuration) and the legacy in-tree barmanObjectStore.
+*/}}
+{{- define "template.recovery.storeConfiguration" -}}
+destinationPath: {{ .Values.recovery.destinationPath | default .Values.backup.destinationPath }}
+endpointURL: {{ .Values.recovery.endpointURL | default .Values.backup.endpointURL }}
+{{- $useRecoveryCA := or .Values.recovery.endpointCA.create .Values.recovery.endpointCA.secretName }}
+{{- $useBackupCA := or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
+{{- if or $useRecoveryCA $useBackupCA }}
+endpointCA:
+  {{- if $useRecoveryCA }}
+  name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
+  key: {{ .Values.recovery.endpointCA.key }}
+  {{- else }}
+  name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
+  key: {{ .Values.backup.endpointCA.key }}
+  {{- end }}
+{{- end }}
+{{- $useRecoveryCreds := or .Values.recovery.s3Credentials.create .Values.recovery.s3Credentials.secretName }}
+s3Credentials:
+  accessKeyId:
+    {{- if $useRecoveryCreds }}
+    name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+    key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
+    {{- else }}
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
+    {{- end }}
+  secretAccessKey:
+    {{- if $useRecoveryCreds }}
+    name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+    key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
+    {{- else }}
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
+    {{- end }}
+  region:
+    {{- if $useRecoveryCreds }}
+    name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
+    key: {{ .Values.recovery.s3Credentials.region.key }}
+    {{- else }}
+    name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
+    key: {{ .Values.backup.s3Credentials.region.key }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Barman object store configuration for the replica store.
+Shared between the plugin ObjectStore CR (spec.configuration) and the legacy in-tree barmanObjectStore.
+*/}}
+{{- define "template.replica.storeConfiguration" -}}
+destinationPath: {{ .Values.replica.destinationPath }}
+endpointURL: {{ .Values.replica.endpointURL }}
+{{- if or .Values.replica.endpointCA.create .Values.replica.endpointCA.secretName }}
+endpointCA:
+  name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
+  key: {{ .Values.replica.endpointCA.key }}
+{{- end }}
+s3Credentials:
+  accessKeyId:
+    name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+    key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
+  secretAccessKey:
+    name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+    key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
+  region:
+    name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
+    key: {{ .Values.replica.s3Credentials.region.key }}
+{{- end }}
+
+{{/*
+Render a barman store configuration with extra fields deep-merged on top (extra fields win, lists are replaced).
+Usage: include "template.mergedStoreConfiguration" (list . "template.backup.storeConfiguration" .Values.backup.extraConfiguration)
+*/}}
+{{- define "template.mergedStoreConfiguration" -}}
+{{- $ctx := index . 0 }}
+{{- $config := include (index . 1) $ctx | fromYaml }}
+{{- with index . 2 }}
+{{- $config = mergeOverwrite $config (deepCopy .) }}
+{{- end }}
+{{- toYaml $config }}
+{{- end }}
+
+{{/*
 DEPRECATED: Legacy backup configuration using in-tree barmanObjectStore.
 This template will be removed in a future version when CloudNativePG drops support for the in-tree method.
 Only use this when backup.legacyMode is explicitly set to true.
@@ -134,48 +272,7 @@ Only use this when backup.legacyMode is explicitly set to true.
 {{- define "template.legacy.backup" -}}
 {{- if and .Values.backup.enabled .Values.backup.legacyMode (ne .Values.mode "recovery") }}
 backup:
-  barmanObjectStore:
-    destinationPath: {{ .Values.backup.destinationPath }}
-    endpointURL: {{ .Values.backup.endpointURL }}
-    {{- if or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
-    endpointCA:
-      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
-      key: {{ .Values.backup.endpointCA.key }}
-    {{- end }}
-    s3Credentials:
-      accessKeyId:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
-      secretAccessKey:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
-      region:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.region.key }}
-    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.jobs }}
-    data:
-      {{- if .Values.backup.compression }}
-      compression: {{ .Values.backup.compression }}
-      {{- end }}
-      {{- if .Values.backup.encryption }}
-      encryption: {{ .Values.backup.encryption }}
-      {{- end }}
-      {{- if .Values.backup.jobs }}
-      jobs: {{ .Values.backup.jobs }}
-      {{- end }}
-    {{- end }}
-    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.maxParallel }}
-    wal:
-      {{- if .Values.backup.compression }}
-      compression: {{ .Values.backup.compression }}
-      {{- end }}
-      {{- if .Values.backup.encryption }}
-      encryption: {{ .Values.backup.encryption }}
-      {{- end }}
-      {{- if .Values.backup.maxParallel }}
-      maxParallel: {{ .Values.backup.maxParallel }}
-      {{- end }}
-    {{- end }}
+  barmanObjectStore: {{- include "template.mergedStoreConfiguration" (list . "template.backup.storeConfiguration" .Values.backup.extraConfiguration) | nindent 4 }}
   retentionPolicy: {{ .Values.backup.retentionPolicy }}
 {{- end }}
 {{- end }}

--- a/charts/cnpg-cluster/templates/backup-object-store.yaml
+++ b/charts/cnpg-cluster/templates/backup-object-store.yaml
@@ -8,48 +8,7 @@ metadata:
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  configuration:
-    destinationPath: {{ .Values.backup.destinationPath }}
-    endpointURL: {{ .Values.backup.endpointURL }}
-    {{- if or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
-    endpointCA:
-      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
-      key: {{ .Values.backup.endpointCA.key }}
-    {{- end }}
-    s3Credentials:
-      accessKeyId:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
-      secretAccessKey:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
-      region:
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.region.key }}
-    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.jobs }}
-    data:
-      {{- if .Values.backup.compression }}
-      compression: {{ .Values.backup.compression }}
-      {{- end }}
-      {{- if .Values.backup.encryption }}
-      encryption: {{ .Values.backup.encryption }}
-      {{- end }}
-      {{- if .Values.backup.jobs }}
-      jobs: {{ .Values.backup.jobs }}
-      {{- end }}
-    {{- end }}
-    {{- if or .Values.backup.compression .Values.backup.encryption .Values.backup.maxParallel }}
-    wal:
-      {{- if .Values.backup.compression }}
-      compression: {{ .Values.backup.compression }}
-      {{- end }}
-      {{- if .Values.backup.encryption }}
-      encryption: {{ .Values.backup.encryption }}
-      {{- end }}
-      {{- if .Values.backup.maxParallel }}
-      maxParallel: {{ .Values.backup.maxParallel }}
-      {{- end }}
-    {{- end }}
+  configuration: {{- include "template.mergedStoreConfiguration" (list . "template.backup.storeConfiguration" .Values.backup.extraConfiguration) | nindent 4 }}
   retentionPolicy: {{ .Values.backup.retentionPolicy }}
   {{- with .Values.backup.extraSpec }}
   {{- toYaml . | nindent 2 }}

--- a/charts/cnpg-cluster/templates/pg-cluster.yaml
+++ b/charts/cnpg-cluster/templates/pg-cluster.yaml
@@ -85,48 +85,12 @@ spec:
   externalClusters:
   - name: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
     {{- if .Values.backup.legacyMode }}
-    barmanObjectStore:
-      destinationPath: {{ .Values.recovery.destinationPath | default .Values.backup.destinationPath }}
-      endpointURL: {{ .Values.recovery.endpointURL | default .Values.backup.endpointURL }}
-      {{- $useRecoveryCA := or .Values.recovery.endpointCA.create .Values.recovery.endpointCA.secretName }}
-      {{- $useBackupCA := or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
-      {{- if or $useRecoveryCA $useBackupCA }}
-      endpointCA:
-        {{- if $useRecoveryCA }}
-        name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
-        key: {{ .Values.recovery.endpointCA.key }}
-        {{- else }}
-        name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
-        key: {{ .Values.backup.endpointCA.key }}
-        {{- end }}
-      {{- end }}
-      {{- $useRecoveryCreds := or .Values.recovery.s3Credentials.create .Values.recovery.s3Credentials.secretName }}
-      s3Credentials:
-        accessKeyId:
-          {{- if $useRecoveryCreds }}
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
-          {{- else }}
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
-          {{- end }}
-        secretAccessKey:
-          {{- if $useRecoveryCreds }}
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
-          {{- else }}
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
-          {{- end }}
-        region:
-          {{- if $useRecoveryCreds }}
-          name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-          key: {{ .Values.recovery.s3Credentials.region.key }}
-          {{- else }}
-          name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-          key: {{ .Values.backup.s3Credentials.region.key }}
-          {{- end }}
-      serverName: {{ .Values.recovery.clusterName | default (include "template.fullname" .) }}
+    {{- $recoveryStore := include "template.recovery.storeConfiguration" . | fromYaml }}
+    {{- $_ := set $recoveryStore "serverName" (.Values.recovery.clusterName | default (include "template.fullname" .)) }}
+    {{- with .Values.recovery.extraConfiguration }}
+    {{- $recoveryStore = mergeOverwrite $recoveryStore (deepCopy .) }}
+    {{- end }}
+    barmanObjectStore: {{- toYaml $recoveryStore | nindent 6 }}
     {{- else }}
     plugin:
       name: barman-cloud.cloudnative-pg.io
@@ -147,25 +111,12 @@ spec:
   externalClusters:
   - name: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
     {{- if .Values.backup.legacyMode }}
-    barmanObjectStore:
-      destinationPath: {{ .Values.replica.destinationPath }}
-      endpointURL: {{ .Values.replica.endpointURL }}
-      {{- if or .Values.replica.endpointCA.create .Values.replica.endpointCA.secretName }}
-      endpointCA:
-        name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
-        key: {{ .Values.replica.endpointCA.key }}
-      {{- end }}
-      s3Credentials:
-        accessKeyId:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
-        secretAccessKey:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
-        region:
-          name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-          key: {{ .Values.replica.s3Credentials.region.key }}
-      serverName: {{ .Values.replica.clusterName | default (include "template.fullname" .) }}
+    {{- $replicaStore := include "template.replica.storeConfiguration" . | fromYaml }}
+    {{- $_ := set $replicaStore "serverName" (.Values.replica.clusterName | default (include "template.fullname" .)) }}
+    {{- with .Values.replica.extraConfiguration }}
+    {{- $replicaStore = mergeOverwrite $replicaStore (deepCopy .) }}
+    {{- end }}
+    barmanObjectStore: {{- toYaml $replicaStore | nindent 6 }}
     {{- else }}
     plugin:
       name: barman-cloud.cloudnative-pg.io

--- a/charts/cnpg-cluster/templates/recovery-object-store.yaml
+++ b/charts/cnpg-cluster/templates/recovery-object-store.yaml
@@ -8,47 +8,7 @@ metadata:
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  configuration:
-    destinationPath: {{ .Values.recovery.destinationPath | default .Values.backup.destinationPath }}
-    endpointURL: {{ .Values.recovery.endpointURL | default .Values.backup.endpointURL }}
-    {{- $useRecoveryCA := or .Values.recovery.endpointCA.create .Values.recovery.endpointCA.secretName }}
-    {{- $useBackupCA := or .Values.backup.endpointCA.create .Values.backup.endpointCA.secretName }}
-    {{- if or $useRecoveryCA $useBackupCA }}
-    endpointCA:
-      {{- if $useRecoveryCA }}
-      name: {{ .Values.recovery.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-ca") }}
-      key: {{ .Values.recovery.endpointCA.key }}
-      {{- else }}
-      name: {{ .Values.backup.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-ca") }}
-      key: {{ .Values.backup.endpointCA.key }}
-      {{- end }}
-    {{- end }}
-    {{- $useRecoveryCreds := or .Values.recovery.s3Credentials.create .Values.recovery.s3Credentials.secretName }}
-    s3Credentials:
-      accessKeyId:
-        {{- if $useRecoveryCreds }}
-        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-        key: {{ .Values.recovery.s3Credentials.accessKeyId.key }}
-        {{- else }}
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.accessKeyId.key }}
-        {{- end }}
-      secretAccessKey:
-        {{- if $useRecoveryCreds }}
-        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-        key: {{ .Values.recovery.s3Credentials.secretAccessKey.key }}
-        {{- else }}
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.secretAccessKey.key }}
-        {{- end }}
-      region:
-        {{- if $useRecoveryCreds }}
-        name: {{ .Values.recovery.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "recovery-creds") }}
-        key: {{ .Values.recovery.s3Credentials.region.key }}
-        {{- else }}
-        name: {{ .Values.backup.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "backup-creds") }}
-        key: {{ .Values.backup.s3Credentials.region.key }}
-        {{- end }}
+  configuration: {{- include "template.mergedStoreConfiguration" (list . "template.recovery.storeConfiguration" .Values.recovery.extraConfiguration) | nindent 4 }}
   {{- with .Values.recovery.extraSpec }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/cnpg-cluster/templates/replica-object-store.yaml
+++ b/charts/cnpg-cluster/templates/replica-object-store.yaml
@@ -8,24 +8,7 @@ metadata:
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  configuration:
-    destinationPath: {{ .Values.replica.destinationPath }}
-    endpointURL: {{ .Values.replica.endpointURL }}
-    {{- if or .Values.replica.endpointCA.create .Values.replica.endpointCA.secretName }}
-    endpointCA:
-      name: {{ .Values.replica.endpointCA.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-ca") }}
-      key: {{ .Values.replica.endpointCA.key }}
-    {{- end }}
-    s3Credentials:
-      accessKeyId:
-        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-        key: {{ .Values.replica.s3Credentials.accessKeyId.key }}
-      secretAccessKey:
-        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-        key: {{ .Values.replica.s3Credentials.secretAccessKey.key }}
-      region:
-        name: {{ .Values.replica.s3Credentials.secretName | default (printf "%s-%s" (include "template.fullname" .) "replica-creds") }}
-        key: {{ .Values.replica.s3Credentials.region.key }}
+  configuration: {{- include "template.mergedStoreConfiguration" (list . "template.replica.storeConfiguration" .Values.replica.extraConfiguration) | nindent 4 }}
   {{- with .Values.replica.extraSpec }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/charts/cnpg-cluster/values.schema.json
+++ b/charts/cnpg-cluster/values.schema.json
@@ -294,6 +294,20 @@
           "type": "integer",
           "description": "Maximum parallel WAL processing during backup."
         },
+        "dataAdditionalCommandArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional command line arguments passed to barman-cloud-backup."
+        },
+        "walAdditionalCommandArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional command line arguments passed to barman-cloud-wal-archive."
+        },
         "destinationPath": {
           "type": "string"
         },
@@ -306,6 +320,10 @@
         "cron": {
           "type": "string",
           "description": "Cron expression for scheduled backups (quoted to handle leading `*`)."
+        },
+        "extraConfiguration": {
+          "type": "object",
+          "description": "Extra fields deep-merged into the barman object store configuration (plugin ObjectStore spec.configuration or legacy in-tree barmanObjectStore)."
         },
         "extraSpec": {
           "type": "object",
@@ -321,6 +339,10 @@
         },
         "endpointURL": {
           "type": "string"
+        },
+        "extraConfiguration": {
+          "type": "object",
+          "description": "Extra fields deep-merged into the recovery barman object store configuration (plugin ObjectStore spec.configuration or legacy in-tree barmanObjectStore)."
         },
         "extraSpec": {
           "type": "object",
@@ -356,6 +378,10 @@
           "type": "string",
           "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
           "default": "prefer"
+        },
+        "extraConfiguration": {
+          "type": "object",
+          "description": "Extra fields deep-merged into the replica barman object store configuration (plugin ObjectStore spec.configuration or legacy in-tree barmanObjectStore)."
         },
         "extraSpec": {
           "type": "object",

--- a/charts/cnpg-cluster/values.yaml
+++ b/charts/cnpg-cluster/values.yaml
@@ -184,6 +184,9 @@ recovery:
     # recoveryTarget:
     #   backupID: 20250214T120000
     #   targetImmediate: true
+  # -- Extra fields deep-merged into the recovery barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `wal.maxParallel`, `wal.restoreAdditionalCommandArgs`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration).
+  # @section -- Recovery mode
+  extraConfiguration: {}
   # -- Extra spec fields merged into the recovery ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
   # @section -- Recovery mode
   extraSpec: {}
@@ -263,6 +266,9 @@ replica:
   # -- Extra configuration of the initDb bootstrap process (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapInitDB).
   # @section -- Replica mode
   extraArgs: {}
+  # -- Extra fields deep-merged into the replica barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `wal.maxParallel`, `wal.restoreAdditionalCommandArgs`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration).
+  # @section -- Replica mode
+  extraConfiguration: {}
   # -- Extra spec fields merged into the replica ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`). Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
   # @section -- Replica mode
   extraSpec: {}
@@ -373,12 +379,21 @@ backup:
   # -- Maximum parallel WAL processing during backup.
   # @section -- Backup
   maxParallel: 1
+  # -- Additional command line arguments passed to `barman-cloud-backup` (e.g. `["--min-chunk-size=100MB"]` to stay under the S3 limit of 1000 multipart upload chunks on large backups).
+  # @section -- Backup
+  dataAdditionalCommandArgs: []
+  # -- Additional command line arguments passed to `barman-cloud-wal-archive` (e.g. `["--read-timeout=60"]`).
+  # @section -- Backup
+  walAdditionalCommandArgs: []
   # -- The cron rule used for cnpg backups. By default it runs every 6 hours.
   # @section -- Backup
   cron: "0 0 */6 * * *"
   # -- Retention policy for cnpg backups recurrences.
   # @section -- Backup
   retentionPolicy: "14d"
+  # -- Extra fields deep-merged into the barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`) for fields not explicitly exposed by this chart (e.g. `tags`, `historyTags`, `data.immediateCheckpoint`, `wal.restoreAdditionalCommandArgs`, `azureCredentials`). Provided fields take precedence over chart-rendered ones; lists are replaced, not merged (See. https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BarmanObjectStoreConfiguration).
+  # @section -- Backup
+  extraConfiguration: {}
   # -- Extra spec fields merged into the ObjectStore CR (e.g. `serverName`, `tags`, `historyTags`, `instanceSidecarConfiguration`) for fields not explicitly exposed by this chart. Only used when `backup.legacyMode` is set to `false` (See. https://cloudnative-pg.io/plugin-barman-cloud/docs/plugin-barman-cloud.v1/#objectstorespec).
   # @section -- Backup
   extraSpec: {}


### PR DESCRIPTION
## Summary

Allow customizing barman-cloud command arguments and any barman object store configuration field not explicitly exposed by the cnpg-cluster chart.

## Purpose & Context

**Problem:** Large base backups fail on S3-compatible storage with `InvalidArgument: Part number must be an integer between 1 and 1000` — barman uploads in ~10MB chunks by default, capping backups at ~10GB. Fixing it requires passing `--min-chunk-size` to `barman-cloud-backup`, which the chart had no way to express. More generally, any barman field outside the chart's whitelist (`tags`, `data.immediateCheckpoint`, `wal.restoreAdditionalCommandArgs`, `azureCredentials`, ...) required a chart change.

**Solution:**
- `backup.dataAdditionalCommandArgs` / `backup.walAdditionalCommandArgs` — extra args for `barman-cloud-backup` and `barman-cloud-wal-archive` (e.g. `["--min-chunk-size=100MB"]`).
- `backup.extraConfiguration`, `recovery.extraConfiguration`, `replica.extraConfiguration` — deep-merged into the barman object store configuration (plugin ObjectStore `spec.configuration` or legacy in-tree `barmanObjectStore`). User fields win on conflict; lists are replaced.

## Changes Made

**Templates:**
- Extract shared `template.{backup,recovery,replica}.storeConfiguration` helpers plus a `template.mergedStoreConfiguration` merge helper in `_helpers.tpl`
- All six render sites (3 stores × plugin/legacy) now consume the shared helpers, removing ~200 lines of duplication and guaranteeing plugin and legacy modes cannot drift apart
- Legacy external-cluster blocks inject `serverName` before the merge so it stays overridable

**Values & schema:**
- New values with helm-docs annotations, `values.schema.json` entries, README regenerated
- Chart version bumped to 2.3.0 with `artifacthub.io/changes` entries

## Testing

**Automated:** ✅ `helm lint` · ✅ full render matrix (primary/recovery/replica × plugin/legacy) verified: correct resource per mode, extra fields applied, chart fields preserved, user overrides win
**Docs:** ✅ regenerated with helm-docs 1.14.2 (matches CI check)

## Breaking Changes

None. New values default to empty and rendered output is semantically identical when unused (keys in the barman configuration are now sorted alphabetically — cosmetic only).

## Additional Notes

`extraSpec` is unchanged and still covers ObjectStore *spec*-level fields (plugin mode only); `extraConfiguration` covers the barman configuration in both modes.